### PR TITLE
feat(cli): add pharos clusters get command

### DIFF
--- a/pkg/pharos/api/client.go
+++ b/pkg/pharos/api/client.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"net/url"
 	"time"
 
 	"github.com/lob/pharos/pkg/pharos/config"
@@ -26,9 +27,23 @@ func NewClient(config *config.Config) *Client {
 	return &Client{c, config}
 }
 
+// ClientFromConfig creates a new Client with its own http.Client
+// using the config file provided.
+func ClientFromConfig(configFile string) (*Client, error) {
+	c, err := config.New(configFile)
+	if err != nil {
+		return nil, err
+	}
+	err = c.Load()
+	if err != nil {
+		return nil, err
+	}
+	return NewClient(c), nil
+}
+
 // send sends a http.Request for the specified method and path, with the given body encoded as JSON.
 // It then marshalls the returned response into the given response interface.
-func (c *Client) send(method string, path string, body interface{}, response interface{}) error {
+func (c *Client) send(method string, path string, body interface{}, response interface{}, query map[string]string) error {
 	buf := &bytes.Buffer{}
 	if body != nil {
 		if err := json.NewEncoder(buf).Encode(body); err != nil {
@@ -42,6 +57,15 @@ func (c *Client) send(method string, path string, body interface{}, response int
 		return errors.Wrap(err, "unable to create http request")
 	}
 	req.Header.Set("Content-Type", "application/json")
+
+	// Add queries to request if there are any.
+	if query != nil {
+		q := url.Values{}
+		for key, value := range query {
+			q.Add(key, value)
+		}
+		req.URL.RawQuery = q.Encode()
+	}
 
 	// Send request.
 	resp, err := c.client.Do(req)

--- a/pkg/pharos/api/client.go
+++ b/pkg/pharos/api/client.go
@@ -43,7 +43,7 @@ func ClientFromConfig(configFile string) (*Client, error) {
 
 // send sends a http.Request for the specified method and path, with the given body encoded as JSON.
 // It then marshalls the returned response into the given response interface.
-func (c *Client) send(method string, path string, body interface{}, response interface{}, query map[string]string) error {
+func (c *Client) send(method string, path string, query map[string]string, body interface{}, response interface{}) error {
 	buf := &bytes.Buffer{}
 	if body != nil {
 		if err := json.NewEncoder(buf).Encode(body); err != nil {

--- a/pkg/pharos/api/client_test.go
+++ b/pkg/pharos/api/client_test.go
@@ -44,7 +44,7 @@ func TestClient(t *testing.T) {
 		// TODO: Test making a GET request to the pharos-api-server when that's been set up.
 		// c := NewClient(Config{BaseURL: "http://localhost:7654"})
 
-		err := c.send(http.MethodGet, "", nil, &cluster, nil)
+		err := c.send(http.MethodGet, "", nil, nil, &cluster)
 		assert.NoError(tt, err)
 		assert.Equal(tt, "production-6906ce", cluster.ID)
 	})
@@ -53,7 +53,7 @@ func TestClient(t *testing.T) {
 		c := NewClient(&config.Config{BaseURL: "bad url"})
 		cluster := model.Cluster{}
 
-		err := c.send("", "", nil, &cluster, nil)
+		err := c.send("", "", nil, nil, &cluster)
 		assert.Error(tt, err)
 		assert.Contains(tt, err.Error(), "unsupported protocol")
 	})

--- a/pkg/pharos/api/client_test.go
+++ b/pkg/pharos/api/client_test.go
@@ -14,6 +14,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const configFile = "../testdata/pharosConfig"
+
 func TestClient(t *testing.T) {
 	var testResponse = []byte(`{
 		"id": "production-6906ce",
@@ -42,7 +44,7 @@ func TestClient(t *testing.T) {
 		// TODO: Test making a GET request to the pharos-api-server when that's been set up.
 		// c := NewClient(Config{BaseURL: "http://localhost:7654"})
 
-		err := c.send(http.MethodGet, "", nil, &cluster)
+		err := c.send(http.MethodGet, "", nil, &cluster, nil)
 		assert.NoError(tt, err)
 		assert.Equal(tt, "production-6906ce", cluster.ID)
 	})
@@ -51,9 +53,20 @@ func TestClient(t *testing.T) {
 		c := NewClient(&config.Config{BaseURL: "bad url"})
 		cluster := model.Cluster{}
 
-		err := c.send("", "", nil, &cluster)
+		err := c.send("", "", nil, &cluster, nil)
 		assert.Error(tt, err)
 		assert.Contains(tt, err.Error(), "unsupported protocol")
+	})
+}
+
+func TestClientFromConfig(t *testing.T) {
+	t.Run("successfully creates a new client", func(tt *testing.T) {
+		c, err := ClientFromConfig(configFile)
+		require.NoError(tt, err)
+		assert.NotNil(tt, c)
+
+		assert.Equal(tt, 10*time.Second, c.client.Timeout)
+		assert.Equal(tt, "pharos.lob-sandbox.com", c.config.BaseURL)
 	})
 }
 

--- a/pkg/pharos/api/client_test.go
+++ b/pkg/pharos/api/client_test.go
@@ -24,7 +24,7 @@ func TestClient(t *testing.T) {
 		"server_url": "https://prod.elb.us-west-2.amazonaws.com:6443",
 		"object": "cluster",
 		"active": true
-		}`)
+	}`)
 	srv := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
 		_, err := rw.Write(testResponse)
 		require.NoError(t, err)

--- a/pkg/pharos/api/pharos.go
+++ b/pkg/pharos/api/pharos.go
@@ -9,10 +9,11 @@ import (
 )
 
 // ListClusters sends a GET request to the clusters endpoint of the Pharos API
-// and returns an array of Clusters.
-func (c *Client) ListClusters() ([]model.Cluster, error) {
+// and returns an array of Clusters. Can also be called with query to retrieve
+// a certain subset of clusters.
+func (c *Client) ListClusters(query map[string]string) ([]model.Cluster, error) {
 	var clusters []model.Cluster
-	err := c.send(http.MethodGet, "clusters", nil, &clusters)
+	err := c.send(http.MethodGet, "clusters", nil, &clusters, query)
 	if err != nil {
 		return clusters, errors.Wrap(err, "failed to list clusters")
 	}
@@ -24,7 +25,7 @@ func (c *Client) ListClusters() ([]model.Cluster, error) {
 // and returns a Cluster.
 func (c *Client) GetCluster(clusterID string) (model.Cluster, error) {
 	var cluster model.Cluster
-	err := c.send(http.MethodGet, fmt.Sprintf("clusters/%s", clusterID), nil, &cluster)
+	err := c.send(http.MethodGet, fmt.Sprintf("clusters/%s", clusterID), nil, &cluster, nil)
 	if err != nil {
 		return cluster, errors.Wrap(err, "failed to get cluster")
 	}

--- a/pkg/pharos/api/pharos.go
+++ b/pkg/pharos/api/pharos.go
@@ -13,7 +13,7 @@ import (
 // a certain subset of clusters.
 func (c *Client) ListClusters(query map[string]string) ([]model.Cluster, error) {
 	var clusters []model.Cluster
-	err := c.send(http.MethodGet, "clusters", nil, &clusters, query)
+	err := c.send(http.MethodGet, "clusters", query, nil, &clusters)
 	if err != nil {
 		return clusters, errors.Wrap(err, "failed to list clusters")
 	}
@@ -25,7 +25,7 @@ func (c *Client) ListClusters(query map[string]string) ([]model.Cluster, error) 
 // and returns a Cluster.
 func (c *Client) GetCluster(clusterID string) (model.Cluster, error) {
 	var cluster model.Cluster
-	err := c.send(http.MethodGet, fmt.Sprintf("clusters/%s", clusterID), nil, &cluster, nil)
+	err := c.send(http.MethodGet, fmt.Sprintf("clusters/%s", clusterID), nil, nil, &cluster)
 	if err != nil {
 		return cluster, errors.Wrap(err, "failed to get cluster")
 	}

--- a/pkg/pharos/api/pharos_test.go
+++ b/pkg/pharos/api/pharos_test.go
@@ -38,7 +38,7 @@ func TestListClusters(t *testing.T) {
 
 	t.Run("lists clusters successfully", func(tt *testing.T) {
 		c := NewClient(&config.Config{BaseURL: srv.URL})
-		clusters, err := c.ListClusters()
+		clusters, err := c.ListClusters(nil)
 		assert.NoError(tt, err)
 
 		assert.Equal(tt, 2, len(clusters))
@@ -47,7 +47,7 @@ func TestListClusters(t *testing.T) {
 
 	t.Run("fails to list clusters using a bad client", func(tt *testing.T) {
 		c := NewClient(&config.Config{BaseURL: ""})
-		clusters, err := c.ListClusters()
+		clusters, err := c.ListClusters(nil)
 		assert.Error(tt, err)
 		assert.Nil(tt, clusters)
 	})

--- a/pkg/pharos/api/pharos_test.go
+++ b/pkg/pharos/api/pharos_test.go
@@ -61,7 +61,7 @@ func TestGetCluster(t *testing.T) {
 		"server_url": "https://prod.elb.us-west-2.amazonaws.com:6443",
 		"object": "cluster",
 		"active": true
-		}`)
+	}`)
 
 	srv := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
 		_, err := rw.Write(testResponse)

--- a/pkg/pharos/cmd/get.go
+++ b/pkg/pharos/cmd/get.go
@@ -1,0 +1,46 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/lob/pharos/pkg/pharos/api"
+	"github.com/lob/pharos/pkg/pharos/kubeconfig"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+)
+
+// Declare some variables to be used as flags.
+var dryRun bool
+
+// GetCmd implements a CLI command that allows users to get cluster information from a new cluster
+// and merge it into an existing kubeconfig file.
+var GetCmd = &cobra.Command{
+	Use:   "get <cluster_id>",
+	Short: "Retrieves information about the specified cluster",
+	Long:  "Retrieves information about the specified cluster and merges it into designated kubeconfig file.",
+	Args:  func(cmd *cobra.Command, args []string) error { return argID(args) },
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := api.ClientFromConfig(pharosConfig)
+		if err != nil {
+			return errors.Wrap(err, "unable to create client from pharos config file")
+		}
+		return runGet(args[0], file, dryRun, client)
+	},
+}
+
+func runGet(cluster string, kubeConfigFile string, dryRun bool, client *api.Client) error {
+	err := kubeconfig.GetCluster(cluster, kubeConfigFile, dryRun, client)
+	if err != nil {
+		return errors.Wrap(err, "failed to get cluster information")
+	}
+	if !dryRun {
+		fmt.Printf("%s CLUSTER MERGED INTO %s.\n", cluster, kubeConfigFile)
+	}
+	return nil
+}
+
+func init() {
+	GetCmd.Flags().BoolVarP(&dryRun, "dry-run", "d", false, "prints the resulting kubeconfig to terminal without any other action")
+	GetCmd.Flags().StringVarP(&file, "file", "f", fmt.Sprintf("%s/.kube/config", os.Getenv("HOME")), "specify kubeconfig file to merge into")
+}

--- a/pkg/pharos/cmd/get.go
+++ b/pkg/pharos/cmd/get.go
@@ -34,9 +34,6 @@ func runGet(cluster string, kubeConfigFile string, dryRun bool, client *api.Clie
 	if err != nil {
 		return errors.Wrap(err, "failed to get cluster information")
 	}
-	if !dryRun {
-		fmt.Printf("%s CLUSTER MERGED INTO %s.\n", cluster, kubeConfigFile)
-	}
 	return nil
 }
 

--- a/pkg/pharos/cmd/get_test.go
+++ b/pkg/pharos/cmd/get_test.go
@@ -1,0 +1,74 @@
+package cmd
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/lob/pharos/pkg/pharos/api"
+	configpkg "github.com/lob/pharos/pkg/pharos/config"
+	"github.com/lob/pharos/pkg/pharos/kubeconfig"
+	"github.com/lob/pharos/pkg/util/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRunGet(t *testing.T) {
+	t.Run("successfully merges information from a cluster into a kubeconfig file", func(tt *testing.T) {
+		// Set up dummy server for testing.
+		var testResponse = []byte(`[{
+		"id": "sandbox-161616",
+		"environment": "sandbox",
+		"cluster_authority_data": "LS0tLS1CRUdJTiBDR...",
+		"server_url": "https://test.elb.us-west-2.amazonaws.com:6443",
+		"object": "cluster",
+		"active": false
+		}]`)
+		srv := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+			_, err := rw.Write(testResponse)
+			require.NoError(tt, err)
+		}))
+		defer srv.Close()
+
+		// Set BaseURL in config to be the url of the dummy server.
+		client := api.NewClient(&(configpkg.Config{BaseURL: srv.URL}))
+
+		// Create temporary test config file and defer cleanup.
+		configFile := test.CopyTestFile(tt, "../testdata", "get", config)
+		defer os.Remove(configFile)
+
+		// Merge cluster information from active cluster for sandbox into configFile.
+		err := runGet("sandbox", configFile, false, client)
+		assert.NoError(tt, err)
+
+		// Check that current context has not been modified.
+		clusterName, err := kubeconfig.CurrentCluster(configFile)
+		assert.NoError(tt, err)
+		assert.Equal(tt, "sandbox", clusterName)
+
+		// Check that a new cluster was added by switching to it and checking whether the switch was successful.
+		err = runSwitch(configFile, "sandbox-161616")
+		assert.NoError(tt, err)
+		clusterName, err = kubeconfig.CurrentCluster(configFile)
+		assert.NoError(tt, err)
+		assert.Equal(tt, "sandbox-161616", clusterName)
+	})
+
+	t.Run("errors when the api server fails to respond with a cluster", func(tt *testing.T) {
+		// Set up dummy server for testing.
+		srv := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+			_, err := rw.Write([]byte(`{}`))
+			require.NoError(tt, err)
+		}))
+		defer srv.Close()
+
+		// Set BaseURL in config to be the url of the dummy server.
+		client := api.NewClient(&(configpkg.Config{BaseURL: srv.URL}))
+
+		// Attempt to merge new cluster into configFile but this should fail because no cluster has been returned.
+		err := runGet("sandbox", config, false, client)
+		assert.Error(tt, err)
+		assert.Contains(tt, err.Error(), "failed to get cluster information")
+	})
+}

--- a/pkg/pharos/cmd/get_test.go
+++ b/pkg/pharos/cmd/get_test.go
@@ -32,7 +32,7 @@ func TestRunGet(t *testing.T) {
 		defer srv.Close()
 
 		// Set BaseURL in config to be the url of the dummy server.
-		client := api.NewClient(&(configpkg.Config{BaseURL: srv.URL}))
+		client := api.NewClient(&configpkg.Config{BaseURL: srv.URL})
 
 		// Create temporary test config file and defer cleanup.
 		configFile := test.CopyTestFile(tt, "../testdata", "get", config)
@@ -64,7 +64,7 @@ func TestRunGet(t *testing.T) {
 		defer srv.Close()
 
 		// Set BaseURL in config to be the url of the dummy server.
-		client := api.NewClient(&(configpkg.Config{BaseURL: srv.URL}))
+		client := api.NewClient(&configpkg.Config{BaseURL: srv.URL})
 
 		// Attempt to merge new cluster into configFile but this should fail because no cluster has been returned.
 		err := runGet("sandbox", config, false, client)

--- a/pkg/pharos/cmd/get_test.go
+++ b/pkg/pharos/cmd/get_test.go
@@ -17,7 +17,7 @@ import (
 func TestRunGet(t *testing.T) {
 	t.Run("successfully merges information from a cluster into a kubeconfig file", func(tt *testing.T) {
 		// Set up dummy server for testing.
-		var testResponse = []byte(`[{
+		testResponse := []byte(`[{
 			"id": "sandbox-161616",
 			"environment": "sandbox",
 			"cluster_authority_data": "LS0tLS1CRUdJTiBDR...",

--- a/pkg/pharos/cmd/get_test.go
+++ b/pkg/pharos/cmd/get_test.go
@@ -18,12 +18,12 @@ func TestRunGet(t *testing.T) {
 	t.Run("successfully merges information from a cluster into a kubeconfig file", func(tt *testing.T) {
 		// Set up dummy server for testing.
 		var testResponse = []byte(`[{
-		"id": "sandbox-161616",
-		"environment": "sandbox",
-		"cluster_authority_data": "LS0tLS1CRUdJTiBDR...",
-		"server_url": "https://test.elb.us-west-2.amazonaws.com:6443",
-		"object": "cluster",
-		"active": false
+			"id": "sandbox-161616",
+			"environment": "sandbox",
+			"cluster_authority_data": "LS0tLS1CRUdJTiBDR...",
+			"server_url": "https://test.elb.us-west-2.amazonaws.com:6443",
+			"object": "cluster",
+			"active": false
 		}]`)
 		srv := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
 			_, err := rw.Write(testResponse)

--- a/pkg/pharos/cmd/root.go
+++ b/pkg/pharos/cmd/root.go
@@ -1,11 +1,16 @@
 package cmd
 
 import (
+	"fmt"
+	"os"
+
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
 // Declare some variables to be used as flags in various commands.
 var file string
+var pharosConfig string
 
 // rootCmd represents the base command when called without any subcommands.
 var rootCmd = &cobra.Command{
@@ -26,6 +31,7 @@ func Execute() error {
 
 func init() {
 	rootCmd.Flags().BoolP("version", "v", false, "print pharos version number")
+	rootCmd.PersistentFlags().StringVarP(&pharosConfig, "config", "c", fmt.Sprintf("%s%s", os.Getenv("HOME"), "/.kube/pharos/config"), "pharos config file")
 
 	// Prevent usage message from being printed out upon command error.
 	rootCmd.SilenceUsage = true
@@ -34,4 +40,17 @@ func init() {
 	rootCmd.AddCommand(clustersCmd)
 	clustersCmd.AddCommand(CurrentCmd)
 	clustersCmd.AddCommand(SwitchCmd)
+	clustersCmd.AddCommand(GetCmd)
+}
+
+// argID prevents commands from being run unless exactly one argument (a cluster name or id)
+// has been passed in. This function is used in many child commands.
+func argID(args []string) error {
+	if len(args) < 1 {
+		return errors.New("requires a cluster name or id argument")
+	}
+	if len(args) > 1 {
+		return errors.New("too many arguments given")
+	}
+	return nil
 }

--- a/pkg/pharos/cmd/root.go
+++ b/pkg/pharos/cmd/root.go
@@ -31,7 +31,7 @@ func Execute() error {
 
 func init() {
 	rootCmd.Flags().BoolP("version", "v", false, "print pharos version number")
-	rootCmd.PersistentFlags().StringVarP(&pharosConfig, "config", "c", fmt.Sprintf("%s%s", os.Getenv("HOME"), "/.kube/pharos/config"), "pharos config file")
+	rootCmd.PersistentFlags().StringVarP(&pharosConfig, "config", "c", fmt.Sprintf("%s/.kube/pharos/config", os.Getenv("HOME")), "pharos config file")
 
 	// Prevent usage message from being printed out upon command error.
 	rootCmd.SilenceUsage = true

--- a/pkg/pharos/cmd/root_test.go
+++ b/pkg/pharos/cmd/root_test.go
@@ -1,8 +1,31 @@
 package cmd
 
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
 // Declare some constants to be used in testing functions used in various commands.
 const (
 	config          = "../testdata/config"
 	malformedConfig = "../testdata/malformed"
 	emptyConfig     = "../testdata/empty"
 )
+
+func TestArgID(t *testing.T) {
+	t.Run("succeeds when we are given exactly one argument", func(tt *testing.T) {
+		err := argID([]string{"1"})
+		require.NoError(tt, err)
+	})
+
+	t.Run("errors if too few arguments are passed in", func(tt *testing.T) {
+		err := argID([]string{})
+		require.Error(tt, err)
+	})
+
+	t.Run("errors if too many arguments are passed in", func(tt *testing.T) {
+		err := argID([]string{"1", "2"})
+		require.Error(tt, err)
+	})
+}

--- a/pkg/pharos/cmd/switch.go
+++ b/pkg/pharos/cmd/switch.go
@@ -31,5 +31,5 @@ func runSwitch(kubeConfigFile string, context string) error {
 }
 
 func init() {
-	SwitchCmd.Flags().StringVarP(&file, "file", "f", fmt.Sprintf("%s%s", os.Getenv("HOME"), "/.kube/config"), "specify designated kubeconfig file")
+	SwitchCmd.Flags().StringVarP(&file, "file", "f", fmt.Sprintf("%s/.kube/config", os.Getenv("HOME")), "specify designated kubeconfig file")
 }

--- a/pkg/pharos/cmd/switch.go
+++ b/pkg/pharos/cmd/switch.go
@@ -14,7 +14,7 @@ var SwitchCmd = &cobra.Command{
 	Use:   "switch <cluster_id>",
 	Short: "Switch to specified cluster",
 	Long:  "Switches the current context in the designated kubeconfig file to the context referencing the specified cluster.",
-	Args:  func(cmd *cobra.Command, args []string) error { return argSwitch(args) },
+	Args:  func(cmd *cobra.Command, args []string) error { return argID(args) },
 	RunE:  func(cmd *cobra.Command, args []string) error { return runSwitch(file, args[0]) },
 }
 
@@ -30,16 +30,6 @@ func runSwitch(kubeConfigFile string, context string) error {
 	return nil
 }
 
-func argSwitch(args []string) error {
-	if len(args) < 1 {
-		return errors.New("requires a cluster name or id argument")
-	}
-	if len(args) > 1 {
-		return errors.New("too many arguments given")
-	}
-	return nil
-}
-
 func init() {
-	SwitchCmd.Flags().StringVarP(&file, "file", "f", os.Getenv("HOME")+"/.kube/config", "specify designated kubeconfig file (defaults to $HOME/.kube/config)")
+	SwitchCmd.Flags().StringVarP(&file, "file", "f", fmt.Sprintf("%s%s", os.Getenv("HOME"), "/.kube/config"), "specify designated kubeconfig file")
 }

--- a/pkg/pharos/cmd/switch_test.go
+++ b/pkg/pharos/cmd/switch_test.go
@@ -32,20 +32,3 @@ func TestRunSwitch(t *testing.T) {
 		assert.Contains(tt, err.Error(), "cluster switch unsuccessful")
 	})
 }
-
-func TestArgSwitch(t *testing.T) {
-	t.Run("succeeds when we are given exactly one argument", func(tt *testing.T) {
-		err := argSwitch([]string{"1"})
-		require.NoError(tt, err)
-	})
-
-	t.Run("errors if too few arguments are passed in", func(tt *testing.T) {
-		err := argSwitch([]string{})
-		require.Error(tt, err)
-	})
-
-	t.Run("errors if too many arguments are passed in", func(tt *testing.T) {
-		err := argSwitch([]string{"1", "2"})
-		require.Error(tt, err)
-	})
-}

--- a/pkg/pharos/kubeconfig/kubeconfig.go
+++ b/pkg/pharos/kubeconfig/kubeconfig.go
@@ -87,7 +87,7 @@ func GetCluster(id string, kubeConfigFile string, dryRun bool, client *api.Clien
 
 	// Set username associated with new cluster.
 	clusterID := cluster.ID
-	username := fmt.Sprintf("engineering-%s", clusterID)
+	username := fmt.Sprintf("iam-%s", clusterID)
 
 	// Update user, context, and cluster information associated with the cluster
 	// in the kubeconfig.

--- a/pkg/pharos/kubeconfig/kubeconfig_test.go
+++ b/pkg/pharos/kubeconfig/kubeconfig_test.go
@@ -120,16 +120,16 @@ func TestGetCluster(t *testing.T) {
 		context, ok := kubeConfig.Contexts["sandbox"]
 		assert.True(tt, ok)
 		assert.Equal(tt, "sandbox-333333", context.Cluster)
-		assert.Equal(tt, "engineering-sandbox-333333", context.AuthInfo)
+		assert.Equal(tt, "iam-sandbox-333333", context.AuthInfo)
 
 		// Check that context for the new cluster exists in the file.
 		context, ok = kubeConfig.Contexts["sandbox-333333"]
 		assert.True(tt, ok)
 		assert.Equal(tt, "sandbox-333333", context.Cluster)
-		assert.Equal(tt, "engineering-sandbox-333333", context.AuthInfo)
+		assert.Equal(tt, "iam-sandbox-333333", context.AuthInfo)
 
 		// Check that new user was created for new cluster.
-		user, ok := kubeConfig.AuthInfos["engineering-sandbox-333333"]
+		user, ok := kubeConfig.AuthInfos["iam-sandbox-333333"]
 		assert.True(tt, ok)
 		assert.Equal(tt, "aws-iam-authenticator", user.Exec.Command)
 		assert.Equal(tt, []string{"token", "-i", "sandbox-333333"}, user.Exec.Args)
@@ -230,10 +230,10 @@ func TestGetCluster(t *testing.T) {
 		context, ok := kubeConfig.Contexts["platform-postmasters"]
 		assert.True(tt, ok)
 		assert.Equal(tt, "platform-postmasters-777777", context.Cluster)
-		assert.Equal(tt, "engineering-platform-postmasters-777777", context.AuthInfo)
+		assert.Equal(tt, "iam-platform-postmasters-777777", context.AuthInfo)
 
 		// Check that new user was created for new cluster.
-		user, ok := kubeConfig.AuthInfos["engineering-platform-postmasters-777777"]
+		user, ok := kubeConfig.AuthInfos["iam-platform-postmasters-777777"]
 		assert.True(tt, ok)
 		assert.Equal(tt, []string{"token", "-i", "platform-postmasters-777777"}, user.Exec.Args)
 		assert.Equal(tt, clientcmdapi.ExecEnvVar{Name: "AWS_PROFILE", Value: "platform-postmasters"}, user.Exec.Env[0])

--- a/pkg/pharos/kubeconfig/kubeconfig_test.go
+++ b/pkg/pharos/kubeconfig/kubeconfig_test.go
@@ -50,7 +50,7 @@ func TestCurrentCluster(t *testing.T) {
 
 func TestGetCluster(t *testing.T) {
 	// Set up dummy server for testing.
-	var getResponse = []byte(`{
+	getResponse := []byte(`{
 		"id":                     "sandbox-222222",
 		"environment":            "sandbox",
 		"cluster_authority_data": "LS0tLS1CRUdJTiBDR...",
@@ -58,7 +58,7 @@ func TestGetCluster(t *testing.T) {
 		"object":                 "cluster",
 		"active":                 false
 	}`)
-	var listResponse = []byte(`[{
+	listResponse := []byte(`[{
 		"id":                     "sandbox-333333",
 		"environment":            "sandbox",
 		"cluster_authority_data": "LS0tLS1CRUdJTiBDR...",
@@ -66,9 +66,9 @@ func TestGetCluster(t *testing.T) {
 		"object":                 "cluster",
 		"active":                 true
 	}]`)
-	var listResponse0 = []byte(`[]`)
-	var listResponse2 = []byte(`[{},{}]`)
-	var listResponse3 = []byte(`[{
+	listResponse0 := []byte(`[]`)
+	listResponse2 := []byte(`[{},{}]`)
+	listResponse3 := []byte(`[{
 		"id":                     "platform-postmasters-777777",
 		"environment":            "platform-postmasters",
 		"cluster_authority_data": "LS0tLS1CRUdJTiBDR...",
@@ -78,23 +78,21 @@ func TestGetCluster(t *testing.T) {
 	}]`)
 
 	srv := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		var response []byte
 		switch r.URL.String() {
 		case "/clusters/sandbox-222222":
-			_, err := rw.Write(getResponse)
-			require.NoError(t, err)
+			response = getResponse
 		case "/clusters?active=true&environment=sandbox":
-			_, err := rw.Write(listResponse)
-			require.NoError(t, err)
+			response = listResponse
 		case "/clusters?active=true&environment=test0clusters":
-			_, err := rw.Write(listResponse0)
-			require.NoError(t, err)
+			response = listResponse0
 		case "/clusters?active=true&environment=test2clusters":
-			_, err := rw.Write(listResponse2)
-			require.NoError(t, err)
+			response = listResponse2
 		case "/clusters?active=true&environment=platform-postmasters":
-			_, err := rw.Write(listResponse3)
-			require.NoError(t, err)
+			response = listResponse3
 		}
+		_, err := rw.Write(response)
+		require.NoError(t, err)
 	}))
 	defer srv.Close()
 
@@ -212,7 +210,7 @@ func TestGetCluster(t *testing.T) {
 		// Received too many clusters from list cluster.
 		err = GetCluster("test2clusters", config, true, client)
 		assert.Error(tt, err)
-		assert.Contains(tt, err.Error(), "multiple clusters found for environment")
+		assert.Contains(tt, err.Error(), "2 clusters found for environment")
 	})
 
 	t.Run("successfully merges new kubeconfig file from cluster using environment with more than one dash into an empty file", func(tt *testing.T) {

--- a/pkg/pharos/kubeconfig/kubeconfig_test.go
+++ b/pkg/pharos/kubeconfig/kubeconfig_test.go
@@ -57,7 +57,7 @@ func TestGetCluster(t *testing.T) {
 		"server_url":             "https://test.elb.us-west-2.amazonaws.com:6443",
 		"object":                 "cluster",
 		"active":                 false
-		}`)
+	}`)
 	var listResponse = []byte(`[{
 		"id":                     "sandbox-333333",
 		"environment":            "sandbox",

--- a/pkg/pharos/kubeconfig/kubeconfig_test.go
+++ b/pkg/pharos/kubeconfig/kubeconfig_test.go
@@ -1,10 +1,15 @@
 package kubeconfig
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"reflect"
+	"strings"
 	"testing"
 
+	"github.com/lob/pharos/pkg/pharos/api"
+	configpkg "github.com/lob/pharos/pkg/pharos/config"
 	"github.com/lob/pharos/pkg/util/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -21,26 +26,164 @@ const (
 func TestCurrentCluster(t *testing.T) {
 	t.Run("successfully retrieves current cluster", func(tt *testing.T) {
 		cluster, err := CurrentCluster(config)
-		require.NoError(tt, err)
+		assert.NoError(tt, err)
 		assert.Equal(tt, "sandbox", cluster)
 	})
 
 	t.Run("errors when reading from malformed config file", func(tt *testing.T) {
 		_, err := CurrentCluster(malformedConfig)
-		require.Error(tt, err)
+		assert.Error(tt, err)
 		assert.Contains(tt, err.Error(), "illegal base64 data at input byte 1")
 	})
 
 	t.Run("errors when reading from empty config file", func(tt *testing.T) {
 		_, err := CurrentCluster(emptyConfig)
-		require.Error(tt, err)
+		assert.Error(tt, err)
 		assert.Contains(tt, err.Error(), "context not found")
 	})
 
 	t.Run("errors when reading from nonexistent config file", func(tt *testing.T) {
 		_, err := CurrentCluster(nonExistentConfig)
-		require.Error(tt, err)
+		assert.Error(tt, err)
 		assert.Contains(tt, err.Error(), "no such file or directory")
+	})
+}
+
+func TestGetCluster(t *testing.T) {
+	// Set up dummy server for testing.
+	var getResponse = []byte(`{
+		"id": "sandbox-222222",
+		"environment": "sandbox",
+		"cluster_authority_data": "LS0tLS1CRUdJTiBDR...",
+		"server_url": "https://test.elb.us-west-2.amazonaws.com:6443",
+		"object": "cluster",
+		"active": false
+		}`)
+	var listResponse = []byte(`[{
+			"id": "sandbox-333333",
+			"environment": "sandbox",
+			"cluster_authority_data": "LS0tLS1CRUdJTiBDR...",
+			"server_url": "https://test.elb.us-west-2.amazonaws.com:6443",
+			"object": "cluster",
+			"active": true
+		}]`)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "/clusters/sandbox-222222") {
+			_, err := rw.Write(getResponse)
+			require.NoError(t, err)
+		} else if strings.Contains(r.URL.String(), "/clusters?active=true&environment=sandbox") {
+			_, err := rw.Write(listResponse)
+			require.NoError(t, err)
+		}
+	}))
+	defer srv.Close()
+
+	// Set BaseURL in config to be the url of the dummy server.
+	client := api.NewClient(&(configpkg.Config{BaseURL: srv.URL}))
+
+	t.Run("successfully merges new kubeconfig file from cluster", func(tt *testing.T) {
+		// Create temporary test config file and defer cleanup.
+		configFile := test.CopyTestFile(tt, "../testdata", "get", config)
+		defer os.Remove(configFile)
+
+		// Merge cluster information from active cluster for sandbox into configFile.
+		err := GetCluster("sandbox", configFile, false, client)
+		assert.NoError(tt, err)
+
+		// Load kubeconfig file for testing.
+		kubeConfig, err := configFromFile(configFile)
+		assert.NoError(tt, err)
+
+		// Load old kubeconfig file for comparison.
+		oldKubeConfig, err := configFromFile(config)
+		assert.NoError(tt, err)
+
+		// Check that context for sandbox has been updated.
+		context, ok := kubeConfig.Contexts["sandbox"]
+		assert.True(tt, ok)
+		assert.Equal(tt, context.Cluster, "sandbox-333333")
+		assert.Equal(tt, context.AuthInfo, "engineering-sandbox-333333")
+
+		// Check that context for the new cluster exists in the file.
+		context, ok = kubeConfig.Contexts["sandbox-333333"]
+		assert.True(tt, ok)
+		assert.Equal(tt, context.Cluster, "sandbox-333333")
+		assert.Equal(tt, context.AuthInfo, "engineering-sandbox-333333")
+
+		// Check that new user was created for new cluster.
+		user, ok := kubeConfig.AuthInfos["engineering-sandbox-333333"]
+		assert.True(tt, ok)
+		assert.Equal(tt, user.Exec.Command, "aws-iam-authenticator")
+		assert.Equal(tt, user.Exec.Args, []string{"token", "-i", "sandbox-333333"})
+
+		// Check that current context has not been modified.
+		assert.Equal(tt, oldKubeConfig.CurrentContext, kubeConfig.CurrentContext)
+	})
+
+	t.Run("successfully creates new kubeconfig file when no previous kubeconfig file exists", func(tt *testing.T) {
+		nonExistentConfig := "../testdata/nonexistentFile"
+		defer os.Remove(nonExistentConfig)
+
+		// Merge cluster information from active cluster for sandbox into nonexistent file.
+		err := GetCluster("sandbox", nonExistentConfig, false, client)
+		assert.NoError(tt, err)
+
+		// Load kubeconfig file for testing.
+		kubeConfig, err := configFromFile(nonExistentConfig)
+		assert.NoError(tt, err)
+
+		// Check that current context has been set because we are starting from a nonexistent file.
+		assert.Equal(tt, "sandbox", kubeConfig.CurrentContext)
+	})
+
+	t.Run("successfully creates new kubeconfig file when kubeconfig file is empty", func(tt *testing.T) {
+		// Create temporary test config file and defer cleanup.
+		configFile := test.CopyTestFile(tt, "../testdata", "get", emptyConfig)
+		defer os.Remove(configFile)
+
+		// Merge cluster information from active cluster for sandbox into configFile.
+		err := GetCluster("sandbox-222222", configFile, false, client)
+		assert.NoError(tt, err)
+
+		// Load kubeconfig file for testing.
+		kubeConfig, err := configFromFile(configFile)
+		assert.NoError(tt, err)
+
+		// Check that current context has been set because we are starting from an empty file.
+		assert.Equal(tt, "sandbox-222222", kubeConfig.CurrentContext)
+	})
+
+	t.Run("takes no action when --dry-run flag is set", func(tt *testing.T) {
+		oldKubeConfig, err := configFromFile(config)
+		assert.NoError(tt, err)
+
+		// Run get cluster with dry-run.
+		err = GetCluster("sandbox", config, true, client)
+		assert.NoError(tt, err)
+
+		// Check that kubeconfig file has not been modified.
+		kubeConfig, err := configFromFile(config)
+		assert.NoError(tt, err)
+		assert.True(tt, reflect.DeepEqual(oldKubeConfig, kubeConfig))
+	})
+
+	t.Run("errors on merging with malformed kubeconfig file", func(tt *testing.T) {
+		err := GetCluster("sandbox", malformedConfig, true, client)
+		assert.Error(tt, err)
+		assert.Contains(tt, err.Error(), "unable to load kubeconfig file")
+	})
+
+	t.Run("errors related to retrieving cluster information from the pharos API", func(tt *testing.T) {
+		// Failed to list cluster.
+		err := GetCluster("production", config, false, client)
+		assert.Error(tt, err)
+		assert.Contains(tt, err.Error(), "unable to list clusters for specified environment")
+
+		// Failed to get cluster.
+		err = GetCluster("sandbox-707070", config, false, client)
+		assert.Error(tt, err)
+		assert.Contains(tt, err.Error(), "failed to get cluster")
 	})
 }
 
@@ -52,50 +195,50 @@ func TestSwitchCluster(t *testing.T) {
 
 		// Check that current cluster is "sandbox".
 		cluster, err := CurrentCluster(configFile)
-		require.NoError(tt, err)
+		assert.NoError(tt, err)
 		assert.Equal(tt, "sandbox", cluster)
 
 		// Switch to context "sandbox-111111".
 		err = SwitchCluster(configFile, "sandbox-111111")
-		require.NoError(tt, err)
+		assert.NoError(tt, err)
 
 		// Check that switch was successful.
 		cluster, err = CurrentCluster(configFile)
-		require.NoError(tt, err)
+		assert.NoError(tt, err)
 		assert.Equal(tt, "sandbox-111111", cluster)
 	})
 
 	t.Run("errors when switching to a cluster that does not exist", func(tt *testing.T) {
 		cluster, err := CurrentCluster(config)
-		require.NoError(tt, err)
+		assert.NoError(tt, err)
 		assert.Equal(tt, "sandbox", cluster)
 
 		// Switch to context "egg".
 		err = SwitchCluster(config, "egg")
-		require.Error(tt, err)
+		assert.Error(tt, err)
 		assert.Contains(tt, err.Error(), "cluster does not exist in context")
 
 		// Current cluster should still be set to sandbox.
 		cluster, err = CurrentCluster(config)
-		require.NoError(tt, err)
+		assert.NoError(tt, err)
 		assert.Equal(tt, "sandbox", cluster)
 	})
 
 	t.Run("errors when switching using malformed config file", func(tt *testing.T) {
 		err := SwitchCluster(malformedConfig, "sandbox")
-		require.Error(tt, err)
+		assert.Error(tt, err)
 		assert.Contains(tt, err.Error(), "illegal base64 data at input byte 1")
 	})
 
 	t.Run("errors when switching using empty config file", func(tt *testing.T) {
 		err := SwitchCluster(emptyConfig, "sandbox")
-		require.Error(tt, err)
+		assert.Error(tt, err)
 		assert.Contains(tt, err.Error(), "cluster does not exist in context")
 	})
 
 	t.Run("errors when switching using nonexistent config file", func(tt *testing.T) {
 		err := SwitchCluster(nonExistentConfig, "sandbox")
-		require.Error(tt, err)
+		assert.Error(tt, err)
 		assert.Contains(tt, err.Error(), "no such file or directory")
 	})
 }
@@ -103,19 +246,19 @@ func TestSwitchCluster(t *testing.T) {
 func TestConfigFromFile(t *testing.T) {
 	t.Run("successfully loads from config file", func(tt *testing.T) {
 		kubeConfig, err := configFromFile(config)
-		require.NoError(tt, err)
+		assert.NoError(tt, err)
 		assert.NotNil(tt, kubeConfig)
 	})
 
 	t.Run("returns empty kubeconfig struct and no error when loading from empty config file", func(tt *testing.T) {
 		kubeConfig, err := configFromFile(emptyConfig)
-		require.NoError(tt, err)
+		assert.NoError(tt, err)
 		assert.True(tt, reflect.DeepEqual(kubeConfig, clientcmdapi.NewConfig()))
 	})
 
 	t.Run("returns nil and error when loading from nonexistent file", func(tt *testing.T) {
 		kubeConfig, err := configFromFile(nonExistentConfig)
-		require.Error(tt, err)
+		assert.Error(tt, err)
 		assert.Nil(tt, kubeConfig)
 	})
 }

--- a/pkg/pharos/testdata/config
+++ b/pkg/pharos/testdata/config
@@ -11,21 +11,21 @@ clusters:
 contexts:
 - context:
     cluster: sandbox-111111
-    user: engineering-sandbox-111111
+    user: iam-sandbox-111111
   name: sandbox
 - context:
     cluster: sandbox-111111
-    user: engineering-sandbox-111111
+    user: iam-sandbox-111111
   name: sandbox-111111
 - context:
     cluster: sandbox-a61631
-    user: engineering-sandbox-a61631
+    user: iam-sandbox-a61631
   name: sandbox-a61631
 current-context: sandbox
 kind: Config
 preferences: {}
 users:
-- name: engineering-sandbox-111111
+- name: iam-sandbox-111111
   user:
     exec:
       apiVersion: client.authentication.k8s.io/v1alpha1
@@ -37,7 +37,7 @@ users:
       env:
       - name: AWS_PROFILE
         value: sandbox
-- name: engineering-sandbox-a61631
+- name: iam-sandbox-a61631
   user:
     exec:
       apiVersion: client.authentication.k8s.io/v1alpha1

--- a/pkg/pharos/testdata/malformed
+++ b/pkg/pharos/testdata/malformed
@@ -7,17 +7,17 @@ clusters:
 contexts:
 - context:
     cluster: sandbox-a61631
-    user: engineering-sandbox-a61631
+    user: iam-sandbox-a61631
   name: EGG
 - context:
     cluster: sandbox-a61631
-    user: engineering-sandbox-a61631
+    user: iam-sandbox-a61631
   name: sandbox-a61631
 current-context: NOT_EGG
 kind: Config
 preferences: {}
 users:
-- name: engineering-sandbox-a61631
+- name: iam-sandbox-a61631
   user:
     exec:
       apiVersion: client.authentication.k8s.io/v1alpha1


### PR DESCRIPTION
### what & why
- adds get cli command to pharos and relevant helper functions
- adds ability for send requests using queries

### notes
- `pharos clusters get` _always_ updates the cluster, context, and user info for a cluster in the kubeconfig file. originally, i implemented checks to avoid updating the kubeconfig file if the cluster already existed in the file (in the interest of performance - to avoid making that extra pharos API call), but decided to just always update in case the file has been inadvertently messed with or users/context/clusters were accidentally deleted from the file. please let me know if you disagree with this design decision 👍 

### testing the CLI locally
merging into an empty kubeconfig file:
![image](https://user-images.githubusercontent.com/10638317/59801535-3f3d1800-929d-11e9-99b0-c1f398d29b02.png)
(i could not test the version where you put in an environment because the list clusters endpoint hasn't been updated to take in a query yet)
![image](https://user-images.githubusercontent.com/10638317/59800829-6cd59180-929c-11e9-9fe6-67e591d7865d.png)
after getting cluster sandbox-111111, merging in cluster production-egg:
![image](https://user-images.githubusercontent.com/10638317/59801003-d3f34600-929c-11e9-8b27-aac696932aa9.png)
help command:
![image](https://user-images.githubusercontent.com/10638317/59801198-23397680-929d-11e9-8fd7-b8d774ce5ab5.png)
