### PR TITLE
feat(binder): create custom binder with payload validation

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -52,6 +52,25 @@
   version = "v8.0.4"
 
 [[projects]]
+  digest = "1:e1ff887e232b2d8f4f7c7db15a5fac7be418025afc4dda53c59c765dbb5aa6b4"
+  name = "github.com/go-playground/locales"
+  packages = [
+    ".",
+    "currency",
+  ]
+  pruneopts = "UT"
+  revision = "f63010822830b6fe52288ee52d5a1151088ce039"
+  version = "v0.12.1"
+
+[[projects]]
+  digest = "1:e022cf244bcac1b6ef933f1a2e0adcf6a6dfd7b872d8d41e4d4179bb09a87cbc"
+  name = "github.com/go-playground/universal-translator"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "b32fa301c9fe55953584134cb6853a13c87ec0a1"
+  version = "v0.16.0"
+
+[[projects]]
   digest = "1:bed9d72d596f94e65fff37f4d6c01398074a6bb1c3f3ceff963516bd01db6ff5"
   name = "github.com/gofrs/uuid"
   packages = ["."]
@@ -136,6 +155,14 @@
   pruneopts = "UT"
   revision = "ab0bfd9a5eba33a8c364bf3390d809ed23c31f97"
   version = "v0.2.9"
+
+[[projects]]
+  digest = "1:6782ffc812e8e700e6952ede1e60487ff1fd9da489eff762985be662a7cfc431"
+  name = "github.com/leodido/go-urn"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "70078a794e8ea4b497ba7c19a78cd60f90ccf0f4"
+  version = "v1.1.0"
 
 [[projects]]
   digest = "1:8a4073008a71ff9009d35de4f9ef33bc8e814d79f284961bbbf8c5ae97fabad3"
@@ -234,6 +261,14 @@
   pruneopts = "UT"
   revision = "acf3980132bfcdc48638724e6e3d9e5749b85999"
   version = "v1.14.3"
+
+[[projects]]
+  digest = "1:700753018409094bbf9b4e19ea0e147458b3aaadf677da3a44ec082d3c075506"
+  name = "github.com/segmentio/go-snakecase"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "5e4a23e7a7bf2d4ede976046611e07ffba02224c"
+  version = "v1.2.0"
 
 [[projects]]
   digest = "1:e096613fb7cf34743d49af87d197663cfccd61876e2219853005a57baedfa562"
@@ -378,6 +413,25 @@
   version = "v1.6.1"
 
 [[projects]]
+  digest = "1:dad6cd59e8bb8d209194efbd3850b5d054384a63061671bfc2a6b2cc0929c731"
+  name = "gopkg.in/go-playground/mold.v2"
+  packages = [
+    ".",
+    "modifiers",
+  ]
+  pruneopts = "UT"
+  revision = "6bc20ce40733e8e04c2fda4523a957dd8e198948"
+  version = "v2.2.0"
+
+[[projects]]
+  digest = "1:ee2db1a4b9111947da887ff2f8972dd2cc80906e521a2d856901fa699b4b51ee"
+  name = "gopkg.in/go-playground/validator.v9"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "884d31b8cad6a1ec877f2400d555924cea03bbea"
+  version = "v9.29.0"
+
+[[projects]]
   digest = "1:2d1fbdc6777e5408cabeb02bf336305e724b925ff4546ded0fa8715a7267922a"
   name = "gopkg.in/inf.v0"
   packages = ["."]
@@ -510,6 +564,9 @@
     "github.com/spf13/cobra",
     "github.com/stretchr/testify/assert",
     "github.com/stretchr/testify/require",
+    "gopkg.in/go-playground/mold.v2",
+    "gopkg.in/go-playground/mold.v2/modifiers",
+    "gopkg.in/go-playground/validator.v9",
     "k8s.io/client-go/tools/clientcmd",
     "k8s.io/client-go/tools/clientcmd/api",
   ]

--- a/internal/test/context.go
+++ b/internal/test/context.go
@@ -1,0 +1,23 @@
+package test
+
+import (
+	"io"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/labstack/echo"
+)
+
+// NewContext returns a new echo.Context, and *httptest.ResponseRecorder to be
+// used for tests.
+func NewContext(t *testing.T, method string, r io.Reader, ctype string) (echo.Context, *httptest.ResponseRecorder) {
+	t.Helper()
+
+	e := echo.New()
+	req := httptest.NewRequest(method, "/", r)
+	req.Header.Set(echo.HeaderContentType, ctype)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	return c, rec
+}

--- a/pkg/pharos-api-server/binder/binder.go
+++ b/pkg/pharos-api-server/binder/binder.go
@@ -1,0 +1,76 @@
+package binder
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"reflect"
+	"strings"
+
+	"github.com/labstack/echo"
+	"gopkg.in/go-playground/mold.v2"
+	"gopkg.in/go-playground/mold.v2/modifiers"
+	"gopkg.in/go-playground/validator.v9"
+)
+
+// Binder is a custom struct that implements the Echo Binder interface. It binds
+// to a struct, uses mold to clean up the params, and validator to validate
+// them.
+type Binder struct {
+	binder   *customBinder
+	conform  *mold.Transformer
+	validate *validator.Validate
+}
+
+// New initializes a new Binder instance with the appropriate validation
+// functions registered.
+func New() *Binder {
+	binder := &customBinder{}
+	conform := modifiers.New()
+	validate := validator.New()
+
+	// RegisterTagNameFunc allows us to specify a function to fetch the name of
+	// the field by tag such that validator.FieldError.Field() returns the JSON
+	// name as opposed to the Go struct field name.
+	validate.RegisterTagNameFunc(func(fld reflect.StructField) string {
+		return strings.SplitN(fld.Tag.Get("json"), ",", 2)[0]
+	})
+
+	return &Binder{binder, conform, validate}
+}
+
+// Bind binds, modifies, and validates payloads against the given struct.
+func (b *Binder) Bind(i interface{}, c echo.Context) error {
+	// Extract values from the request in the echo.Context into our interface i.
+	if err := b.binder.bind(i, c); err != nil {
+		return err
+	}
+
+	// Modify values based on the struct tags in our interface. Most likely this
+	// is trimming whitespace from values.
+	if err := b.conform.Struct(context.Background(), i); err != nil {
+		return err
+	}
+
+	// Validate that the values on our struct are valid. If there are any errors,
+	// format the first error and return it as an HTTP error.
+	if err := b.validate.Struct(i); err != nil {
+		errs := err.(validator.ValidationErrors)
+		msg := format(errs[0])
+		return echo.NewHTTPError(http.StatusUnprocessableEntity, msg)
+	}
+
+	return nil
+}
+
+func format(err validator.FieldError) string {
+	if err.Tag() == "required" {
+		return fmt.Sprintf("%s is required", err.Field())
+	}
+
+	if err.Tag() == "url" {
+		return fmt.Sprintf("%s must be a valid URL", err.Field())
+	}
+
+	return fmt.Sprintf("%s is invalid", err.Field())
+}

--- a/pkg/pharos-api-server/binder/binder_test.go
+++ b/pkg/pharos-api-server/binder/binder_test.go
@@ -1,0 +1,50 @@
+package binder
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/labstack/echo"
+	"github.com/lob/pharos/internal/test"
+	"github.com/stretchr/testify/assert"
+)
+
+type params struct {
+	Environment string `json:"environment" mod:"trim" validate:"required"`
+	ServerURL   string `json:"server_url" validate:"required,url"`
+}
+
+func TestNew(t *testing.T) {
+	b := New()
+	assert.NotNil(t, b)
+	assert.NotNil(t, b.binder)
+	assert.NotNil(t, b.conform)
+	assert.NotNil(t, b.validate)
+}
+
+func TestBind(t *testing.T) {
+	b := New()
+	assert.NotNil(t, b)
+
+	t.Run("enforces required values", func(tt *testing.T) {
+		c, _ := test.NewContext(tt, echo.GET, strings.NewReader("{}"), echo.MIMEApplicationJSON)
+		p := params{}
+		err := b.Bind(&p, c)
+		assert.Contains(t, err.Error(), "is required")
+	})
+
+	t.Run("trims whitespace", func(tt *testing.T) {
+		c, _ := test.NewContext(tt, echo.GET, strings.NewReader(`{"environment": " test ", "server_url": "https://pharos.com"}`), echo.MIMEApplicationJSON)
+		p := params{}
+		err := b.Bind(&p, c)
+		assert.NoError(t, err)
+		assert.Equal(t, p.Environment, "test")
+	})
+
+	t.Run("enforces url", func(tt *testing.T) {
+		c, _ := test.NewContext(tt, echo.GET, strings.NewReader(`{"environment": "test", "server_url": "foobar"}`), echo.MIMEApplicationJSON)
+		p := params{}
+		err := b.Bind(&p, c)
+		assert.Contains(t, err.Error(), "server_url must be a valid URL")
+	})
+}

--- a/pkg/pharos-api-server/binder/custom_binder.go
+++ b/pkg/pharos-api-server/binder/custom_binder.go
@@ -1,0 +1,37 @@
+package binder
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+
+	"github.com/labstack/echo"
+)
+
+type customBinder struct{}
+
+func (cb *customBinder) bind(i interface{}, c echo.Context) error {
+	req := c.Request()
+
+	if req.ContentLength == 0 {
+		if req.Method == http.MethodGet || req.Method == http.MethodDelete {
+			return nil
+		}
+		return echo.NewHTTPError(http.StatusBadRequest, "request body can't be empty")
+	}
+
+	contentType := req.Header.Get(echo.HeaderContentType)
+
+	if strings.HasPrefix(contentType, echo.MIMEApplicationJSON) {
+		d := json.NewDecoder(req.Body)
+		d.DisallowUnknownFields()
+
+		if err := d.Decode(i); err != nil {
+			return echo.NewHTTPError(http.StatusBadRequest, err.Error())
+		}
+
+		return nil
+	}
+
+	return echo.ErrUnsupportedMediaType
+}

--- a/pkg/pharos-api-server/binder/custom_binder_test.go
+++ b/pkg/pharos-api-server/binder/custom_binder_test.go
@@ -1,0 +1,65 @@
+package binder
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/labstack/echo"
+	"github.com/lob/pharos/internal/test"
+	"github.com/stretchr/testify/assert"
+)
+
+type user struct {
+	ID   int    `json:"id"`
+	Name string `json:"name"`
+}
+
+func TestCustomBinderBind(t *testing.T) {
+	cb := &customBinder{}
+	u := &user{}
+
+	t.Run("successfully binds payload", func(tt *testing.T) {
+		c, _ := test.NewContext(tt, echo.GET, strings.NewReader(`{"id": 123, "name": "test"}`), echo.MIMEApplicationJSON)
+
+		err := cb.bind(u, c)
+		assert.NoError(tt, err)
+		assert.Equal(tt, 123, u.ID)
+		assert.Equal(tt, "test", u.Name)
+	})
+
+	t.Run("errors for unknown fields in payload", func(tt *testing.T) {
+		c, _ := test.NewContext(tt, echo.GET, strings.NewReader(`{"foo": "bar"}`), echo.MIMEApplicationJSON)
+
+		err := cb.bind(u, c)
+		assert.Contains(tt, err.Error(), `unknown field "foo"`)
+	})
+
+	t.Run("errors for unknown MIME", func(tt *testing.T) {
+		c, _ := test.NewContext(tt, echo.GET, strings.NewReader("test"), echo.MIMETextPlain)
+
+		err := cb.bind(u, c)
+		assert.Contains(tt, err.Error(), "Unsupported Media Type")
+	})
+
+	t.Run("errors with empty payloads for non GET or DELETE requests", func(tt *testing.T) {
+		c, _ := test.NewContext(tt, echo.POST, strings.NewReader(""), echo.MIMEApplicationJSON)
+
+		err := cb.bind(u, c)
+		assert.Contains(tt, err.Error(), "request body can't be empty")
+	})
+
+	t.Run("allows empty GET request", func(tt *testing.T) {
+		c, _ := test.NewContext(tt, echo.GET, strings.NewReader(""), echo.MIMEApplicationJSON)
+
+		err := cb.bind(u, c)
+		assert.NoError(tt, err)
+	})
+
+	t.Run("allows empty DELETE request", func(tt *testing.T) {
+		c, _ := test.NewContext(tt, echo.DELETE, strings.NewReader(""), echo.MIMEApplicationJSON)
+
+		err := cb.bind(u, c)
+		assert.NoError(tt, err)
+	})
+
+}

--- a/pkg/pharos-api-server/server/server.go
+++ b/pkg/pharos-api-server/server/server.go
@@ -11,6 +11,7 @@ import (
 	logger "github.com/lob/logger-go"
 	metrics "github.com/lob/metrics-go"
 	"github.com/lob/pharos/pkg/pharos-api-server/application"
+	"github.com/lob/pharos/pkg/pharos-api-server/binder"
 	"github.com/lob/pharos/pkg/pharos-api-server/health"
 	"github.com/lob/pharos/pkg/pharos-api-server/recovery"
 	"github.com/lob/pharos/pkg/pharos-api-server/signals"
@@ -21,6 +22,9 @@ import (
 func New(app application.App) *http.Server {
 	e := echo.New()
 	log := logger.New()
+
+	b := binder.New()
+	e.Binder = b
 
 	e.Use(metrics.Middleware(app.Metrics))
 	e.Use(logger.Middleware())


### PR DESCRIPTION
## What & Why
- [x] Create a custom echo Binder to bind, conform and validate payloads into Go structs.

## Notes
`customBinder` is a pretty minimal Binder based on the Echo binder. The main differences are that it only supports JSON payloads, doesn't bind query params (we won't be using them) and the JSON parsing returns an error if it contains unknown JSON keys instead of silently dropping them (this is the main reason to have the custom binder over the default echo Binder).