### PR TITLE
feat(api-client): add package for pharos api client

### DIFF
--- a/pkg/pharos/api/client.go
+++ b/pkg/pharos/api/client.go
@@ -1,0 +1,88 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"time"
+
+	"github.com/lob/pharos/pkg/pharos/config"
+	"github.com/pkg/errors"
+)
+
+// Client is a struct containing information for an api client.
+type Client struct {
+	client *http.Client
+	config *config.Config
+}
+
+// NewClient creates a new Client with its own http.Client.
+func NewClient(config *config.Config) *Client {
+	c := &http.Client{
+		Timeout: 10 * time.Second,
+	}
+	return &Client{c, config}
+}
+
+// send sends a http.Request for the specified method and path, with the given body encoded as JSON.
+// It then marshalls the returned response into the given response interface.
+func (c *Client) send(method string, path string, body interface{}, response interface{}) error {
+	buf := &bytes.Buffer{}
+	if body != nil {
+		if err := json.NewEncoder(buf).Encode(body); err != nil {
+			return err
+		}
+	}
+
+	// Create http request with json body.
+	req, err := http.NewRequest(method, fmt.Sprintf("%s/%s", c.config.BaseURL, path), buf)
+	if err != nil {
+		return errors.Wrap(err, "unable to create http request")
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	// Send request.
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return errors.Wrap(err, "failed to send http request")
+	}
+	defer resp.Body.Close()
+
+	err = checkError(resp)
+	if err != nil {
+		return errors.Wrap(err, "response contained error")
+	}
+
+	// Parse response body.
+	respBody, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return errors.Wrap(err, "could not read response body")
+	}
+
+	if err = json.Unmarshal(respBody, response); err != nil {
+		return errors.Wrap(err, "could not unmarshal response into interface")
+	}
+
+	return nil
+}
+
+func checkError(resp *http.Response) error {
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		return nil
+	}
+
+	errMsg := new(struct {
+		Err struct {
+			Message string `json:"message"`
+		} `json:"error"`
+	})
+
+	err := json.NewDecoder(resp.Body).Decode(errMsg)
+	if err != nil {
+		return errors.Wrap(err, http.StatusText((resp.StatusCode)))
+	}
+
+	return fmt.Errorf("%s (%d)", errMsg.Err.Message, resp.StatusCode)
+}

--- a/pkg/pharos/api/client_test.go
+++ b/pkg/pharos/api/client_test.go
@@ -1,0 +1,77 @@
+package api
+
+import (
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/lob/pharos/pkg/pharos/config"
+	"github.com/lob/pharos/pkg/util/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestClient(t *testing.T) {
+	var testResponse = []byte(`{
+		"id": "production-6906ce",
+		"environment": "production",
+		"cluster_authority_data": "LS0tLS1CRUdJTiBDR...",
+		"server_url": "https://prod.elb.us-west-2.amazonaws.com:6443",
+		"object": "cluster",
+		"active": true
+		}`)
+	srv := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		_, err := rw.Write(testResponse)
+		require.NoError(t, err)
+	}))
+	defer srv.Close()
+
+	t.Run("successfully creates a new client", func(tt *testing.T) {
+		c := NewClient(&config.Config{})
+		assert.NotNil(tt, c)
+
+		assert.Equal(tt, 10*time.Second, c.client.Timeout)
+	})
+
+	t.Run("send makes a successful GET request", func(tt *testing.T) {
+		c := NewClient(&config.Config{BaseURL: srv.URL})
+		cluster := model.Cluster{}
+		// TODO: Test making a GET request to the pharos-api-server when that's been set up.
+		// c := NewClient(Config{BaseURL: "http://localhost:7654"})
+
+		err := c.send(http.MethodGet, "", nil, &cluster)
+		assert.NoError(tt, err)
+		assert.Equal(tt, "production-6906ce", cluster.ID)
+	})
+
+	t.Run("correctly bubbles up HTTP errors", func(tt *testing.T) {
+		c := NewClient(&config.Config{BaseURL: "bad url"})
+		cluster := model.Cluster{}
+
+		err := c.send("", "", nil, &cluster)
+		assert.Error(tt, err)
+		assert.Contains(tt, err.Error(), "unsupported protocol")
+	})
+}
+
+func TestCheckError(t *testing.T) {
+	t.Run("fails upon receiving a response with a bad status code", func(tt *testing.T) {
+		err := checkError(&http.Response{
+			Body:       ioutil.NopCloser(strings.NewReader(`{"error": {"message" : "internal server error"}}`)),
+			StatusCode: http.StatusInternalServerError,
+		})
+		assert.Error(tt, err)
+		assert.Contains(tt, err.Error(), "internal server error")
+	})
+
+	t.Run("returns nil upon receiving a response with no errors", func(tt *testing.T) {
+		err := checkError(&http.Response{
+			Body:       ioutil.NopCloser(strings.NewReader("{ok}")),
+			StatusCode: http.StatusOK,
+		})
+		assert.NoError(tt, err)
+	})
+}

--- a/pkg/pharos/api/pharos.go
+++ b/pkg/pharos/api/pharos.go
@@ -1,0 +1,33 @@
+package api
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/lob/pharos/pkg/util/model"
+	"github.com/pkg/errors"
+)
+
+// ListClusters sends a GET request to the clusters endpoint of the Pharos API
+// and returns an array of Clusters.
+func (c *Client) ListClusters() ([]model.Cluster, error) {
+	var clusters []model.Cluster
+	err := c.send(http.MethodGet, "clusters", nil, &clusters)
+	if err != nil {
+		return clusters, errors.Wrap(err, "failed to list clusters")
+	}
+
+	return clusters, nil
+}
+
+// GetCluster sends a GET request to the clusters/id endpoint of the Pharos API
+// and returns a Cluster.
+func (c *Client) GetCluster(clusterID string) (model.Cluster, error) {
+	var cluster model.Cluster
+	err := c.send(http.MethodGet, fmt.Sprintf("clusters/%s", clusterID), nil, &cluster)
+	if err != nil {
+		return cluster, errors.Wrap(err, "failed to get cluster")
+	}
+
+	return cluster, nil
+}

--- a/pkg/pharos/api/pharos_test.go
+++ b/pkg/pharos/api/pharos_test.go
@@ -1,0 +1,85 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/lob/pharos/pkg/pharos/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestListClusters(t *testing.T) {
+	var testResponse = []byte(`[
+		{
+			"id": "production-6906ce",
+			"environment": "production",
+			"cluster_authority_data": "LS0tLS1CRUdJTiBDR...",
+			"server_url": "https://prod.elb.us-west-2.amazonaws.com:6443",
+			"object": "cluster",
+			"active": true
+		},
+		{
+			"id": "production-111111",
+			"environment": "production",
+			"cluster_authority_data": "LS0tLS1CRsdJTiBDR...",
+			"server_url": "https://prod.elb.us-west-2.amazonaws.com:6443",
+			"object": "cluster",
+			"active": false
+		}
+	]`)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		_, err := rw.Write(testResponse)
+		require.NoError(t, err)
+	}))
+	defer srv.Close()
+
+	t.Run("lists clusters successfully", func(tt *testing.T) {
+		c := NewClient(&config.Config{BaseURL: srv.URL})
+		clusters, err := c.ListClusters()
+		assert.NoError(tt, err)
+
+		assert.Equal(tt, 2, len(clusters))
+		assert.Equal(tt, "production-6906ce", (clusters)[0].ID)
+	})
+
+	t.Run("fails to list clusters using a bad client", func(tt *testing.T) {
+		c := NewClient(&config.Config{BaseURL: ""})
+		clusters, err := c.ListClusters()
+		assert.Error(tt, err)
+		assert.Nil(tt, clusters)
+	})
+}
+
+func TestGetCluster(t *testing.T) {
+	var testResponse = []byte(`{
+		"id": "production-6906ce",
+		"environment": "production",
+		"cluster_authority_data": "LS0tLS1CRUdJTiBDR...",
+		"server_url": "https://prod.elb.us-west-2.amazonaws.com:6443",
+		"object": "cluster",
+		"active": true
+		}`)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		_, err := rw.Write(testResponse)
+		require.NoError(t, err)
+	}))
+	defer srv.Close()
+
+	t.Run("retrieves cluster by ID successfully", func(tt *testing.T) {
+		c := NewClient(&config.Config{BaseURL: srv.URL})
+		cluster, err := c.GetCluster("production-6906ce")
+		assert.NoError(tt, err)
+		assert.Equal(tt, "production", cluster.Environment)
+	})
+
+	t.Run("fails to retrieve cluster using a bad client", func(tt *testing.T) {
+		c := NewClient(&config.Config{BaseURL: ""})
+		cluster, err := c.GetCluster("production-6906ce")
+		assert.Error(tt, err)
+		assert.Equal(tt, "", cluster.ID)
+	})
+}

--- a/pkg/pharos/cmd/switch_test.go
+++ b/pkg/pharos/cmd/switch_test.go
@@ -1,26 +1,27 @@
 package cmd
 
 import (
+	"os"
 	"testing"
 
 	"github.com/lob/pharos/pkg/pharos/kubeconfig"
+	"github.com/lob/pharos/pkg/util/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestRunSwitch(t *testing.T) {
 	t.Run("successfully switches to existing cluster", func(tt *testing.T) {
-		// Switch back to context "sandbox".
-		defer func() {
-			err := runSwitch(config, "sandbox")
-			require.NoError(tt, err)
-		}()
+		// Create temporary test config file and defer cleanup.
+		configFile := test.CopyTestFile(tt, "../testdata", "switch", config)
+		defer os.Remove(configFile)
 
-		err := runSwitch(config, "sandbox-111111")
+		// Switch to a different cluster.
+		err := runSwitch(configFile, "sandbox-111111")
 		require.NoError(tt, err)
 
 		// Check that switch was successful.
-		clusterName, err := kubeconfig.CurrentCluster(config)
+		clusterName, err := kubeconfig.CurrentCluster(configFile)
 		require.NoError(tt, err)
 		require.Equal(tt, "sandbox-111111", clusterName)
 	})

--- a/pkg/pharos/config/config.go
+++ b/pkg/pharos/config/config.go
@@ -1,0 +1,52 @@
+package config
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+)
+
+// Config contains the configuration for this CLI.
+// It is used to create a Client for the Pharos API server.
+type Config struct {
+	BaseURL    string `json:"base_url"`
+	AWSProfile string `json:"aws_profile"`
+	filePath   string
+}
+
+const (
+	directoryPermissions = 0700
+)
+
+// New creates a new Config reference at the given file path.
+// Defaults to creating a Config reference at $HOME/.kube/pharos/config.
+func New(pharosConfig string) (*Config, error) {
+	if pharosConfig == "" {
+		pharosConfig = fmt.Sprintf("%s/.kube/pharos/config", os.Getenv("HOME"))
+	}
+	dir := filepath.Dir(pharosConfig)
+	err := os.MkdirAll(dir, directoryPermissions)
+	if err != nil {
+		return nil, err
+	}
+	return &Config{filePath: pharosConfig}, nil
+}
+
+// Load loads data from the config file into the Config struct.
+func (c *Config) Load() error {
+	if _, err := os.Stat(c.filePath); os.IsNotExist(err) {
+		return errors.New("pharos hasn't been configured yet")
+	}
+	raw, err := ioutil.ReadFile(c.filePath)
+	if err != nil {
+		return err
+	}
+	if string(raw) == "" {
+		return errors.New("pharos hasn't been configured yet")
+	}
+
+	return json.Unmarshal(raw, c)
+}

--- a/pkg/pharos/config/config_test.go
+++ b/pkg/pharos/config/config_test.go
@@ -1,0 +1,62 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	pharosConfig = "../testdata/pharosConfig"
+	empty        = "../testdata/empty"
+	nonexistent  = "../testdata/nonexistent"
+)
+
+func TestNew(t *testing.T) {
+	t.Run("successfully creates reference to existing config file", func(tt *testing.T) {
+		c, err := New(pharosConfig)
+		assert.NoError(tt, err)
+		assert.Equal(tt, pharosConfig, c.filePath)
+	})
+
+	t.Run("defaults to creating a config file reference at $HOME/.kube/pharos/config", func(tt *testing.T) {
+		c, err := New("")
+		assert.NoError(tt, err)
+		assert.Equal(tt, fmt.Sprintf("%s/.kube/pharos/config", os.Getenv("HOME")), c.filePath)
+	})
+}
+
+func TestLoad(t *testing.T) {
+	t.Run("successfully loads existing config file", func(tt *testing.T) {
+		// Create reference to config file.
+		c, err := New(pharosConfig)
+		assert.NoError(tt, err)
+
+		// Loads file successfully into struct.
+		err = c.Load()
+		assert.NoError(tt, err)
+		assert.Equal(tt, "pharos.lob-sandbox.com", c.BaseURL)
+	})
+
+	t.Run("fails to load from nonexistent config", func(tt *testing.T) {
+		c, err := New(nonexistent)
+		assert.NoError(tt, err)
+		assert.Equal(tt, nonexistent, c.filePath)
+
+		err = c.Load()
+		assert.Error(tt, err)
+		assert.Contains(tt, err.Error(), "pharos hasn't been configured yet")
+	})
+
+	t.Run("fails to load from empty config", func(tt *testing.T) {
+		c, err := New(empty)
+		assert.NoError(tt, err)
+		assert.Equal(tt, empty, c.filePath)
+
+		err = c.Load()
+		assert.Error(tt, err)
+		assert.Contains(tt, err.Error(), "pharos hasn't been configured yet")
+	})
+}

--- a/pkg/pharos/kubeconfig/kubeconfig_test.go
+++ b/pkg/pharos/kubeconfig/kubeconfig_test.go
@@ -1,9 +1,11 @@
 package kubeconfig
 
 import (
+	"os"
 	"reflect"
 	"testing"
 
+	"github.com/lob/pharos/pkg/util/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
@@ -44,23 +46,21 @@ func TestCurrentCluster(t *testing.T) {
 
 func TestSwitchCluster(t *testing.T) {
 	t.Run("successfully switches to cluster", func(tt *testing.T) {
-		// Switch back to context "sandbox".
-		defer func() {
-			err := SwitchCluster(config, "sandbox")
-			require.NoError(tt, err)
-		}()
+		// Create temporary test config file and defer cleanup.
+		configFile := test.CopyTestFile(tt, "../testdata", "switch", config)
+		defer os.Remove(configFile)
 
 		// Check that current cluster is "sandbox".
-		cluster, err := CurrentCluster(config)
+		cluster, err := CurrentCluster(configFile)
 		require.NoError(tt, err)
 		assert.Equal(tt, "sandbox", cluster)
 
 		// Switch to context "sandbox-111111".
-		err = SwitchCluster(config, "sandbox-111111")
+		err = SwitchCluster(configFile, "sandbox-111111")
 		require.NoError(tt, err)
 
 		// Check that switch was successful.
-		cluster, err = CurrentCluster(config)
+		cluster, err = CurrentCluster(configFile)
 		require.NoError(tt, err)
 		assert.Equal(tt, "sandbox-111111", cluster)
 	})

--- a/pkg/pharos/testdata/pharosConfig
+++ b/pkg/pharos/testdata/pharosConfig
@@ -1,0 +1,4 @@
+{
+  "base_url": "pharos.lob-sandbox.com",
+  "aws_profile": "sandbox"
+}

--- a/pkg/util/test/test.go
+++ b/pkg/util/test/test.go
@@ -1,0 +1,38 @@
+package test
+
+import (
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// CopyTestFile copies the contents of a designated file to a temporary file and returns
+// the filepath of the temporary file for cleanup.
+// This function does NOT clean up created temporary files.
+// Borrows from: https://opensource.com/article/18/6/copying-files-go
+func CopyTestFile(t *testing.T, dstDir, dstPrefix, src string) string {
+	t.Helper()
+
+	// Create temporary destination file.
+	destination, err := ioutil.TempFile(dstDir, dstPrefix)
+	require.NoError(t, err)
+	defer destination.Close()
+
+	sourceFileStat, err := os.Stat(src)
+	require.NoError(t, err)
+	require.True(t, sourceFileStat.Mode().IsRegular())
+
+	source, err := os.Open(filepath.Clean(src))
+	require.NoError(t, err)
+	defer source.Close()
+
+	// Copy file from source to destination.
+	_, err = io.Copy(destination, source)
+	require.NoError(t, err)
+
+	return destination.Name()
+}


### PR DESCRIPTION
### what & why
- adds a client for the pharos API
- adds help functions for sending requests to the pharos API via a client
- adds a help function for testing (creating temporary copies of files)
- adds a config for the pharos CLI that can be loaded and saved to a file

### notes
- the client doesn't handle authentication at the moment, we'll need to add support for that later