### PR TITLE
feat(cli): add pharos clusters list command

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -56,6 +56,14 @@
   version = "v1.1.1"
 
 [[projects]]
+  digest = "1:938a2672d6ebbb7f7bc63eee3e4b9464c16ffcf77ec8913d3edbf32b4e3984dd"
+  name = "github.com/fatih/color"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "570b54cabe6b8eb0bc2dfce68d964677d63b5260"
+  version = "v1.5.0"
+
+[[projects]]
   digest = "1:d18f6f088d7d8365df47f49dfa24b6ff6701a941118ffda30c589d1bd954074b"
   name = "github.com/getsentry/raven-go"
   packages = ["."]
@@ -595,6 +603,7 @@
     "github.com/aws/aws-sdk-go/aws/request",
     "github.com/aws/aws-sdk-go/service/sts",
     "github.com/aws/aws-sdk-go/service/sts/stsiface",
+    "github.com/fatih/color",
     "github.com/go-pg/pg",
     "github.com/go-pg/pg/orm",
     "github.com/labstack/echo",

--- a/pkg/pharos/cli/cli.go
+++ b/pkg/pharos/cli/cli.go
@@ -1,10 +1,12 @@
-package kubeconfig
+package cli
 
 import (
 	"fmt"
 	"os"
 	"regexp"
+	"strconv"
 
+	"github.com/fatih/color"
 	"github.com/lob/pharos/pkg/pharos/api"
 	"github.com/lob/pharos/pkg/util/model"
 	"github.com/pkg/errors"
@@ -29,7 +31,7 @@ func CurrentCluster(kubeConfigFile string) (string, error) {
 }
 
 // GetCluster gets information from a new cluster
-// and merges it into an existing kubeconfig file
+// and merges it into an existing kubeconfig file.
 func GetCluster(id string, kubeConfigFile string, dryRun bool, client *api.Client) error {
 	// Check whether given kubeconfig file already exists. If it does not, create a new kubeconfig
 	// file in the specified file location. Return an error only if file is malformed, but not
@@ -120,8 +122,33 @@ func GetCluster(id string, kubeConfigFile string, dryRun bool, client *api.Clien
 	if err != nil {
 		return err
 	}
-	fmt.Printf("%s CLUSTER MERGED INTO %s.\n", id, kubeConfigFile)
+	fmt.Printf("%s %s MERGED INTO %s\n", color.GreenString("SUCCESS:"), id, kubeConfigFile)
 	return nil
+}
+
+// ListClusters retrieves all clusters and returns a formatted string
+// of all clusters. If given an environment, ListClusters will only retrieve
+// the clusters for that environment.
+func ListClusters(env string, client *api.Client) (string, error) {
+	var query map[string]string
+	if env != "" {
+		query = map[string]string{
+			"active":      "true",
+			"environment": env,
+		}
+	}
+
+	c, err := client.ListClusters(query)
+	if err != nil {
+		return "", errors.Wrap(err, "unable to list clusters for specified environment")
+	}
+
+	clusters := color.CyanString(fmt.Sprintf("%-30s%-24s%-10s%s", "CLUSTER_ID", "ENVIRONMENT", "ACTIVE", "SERVER"))
+	for _, cluster := range c {
+		clusters = fmt.Sprintf("%s\n%-30s%-24s%-10s%-s", clusters, cluster.ID, cluster.Environment, strconv.FormatBool(cluster.Active), cluster.ServerURL)
+	}
+
+	return clusters, nil
 }
 
 // SwitchCluster switches current context to given cluster or context name.
@@ -147,55 +174,4 @@ func SwitchCluster(kubeConfigFile string, context string) error {
 	}
 
 	return clientcmd.WriteToFile(*kubeConfig, kubeConfigFile)
-}
-
-// configFromFile returns a struct containing kubeconfig information from a file.
-// Does not differentiate between errors resulting from a missing file and errors
-// from reading from a malformed config.
-// Function source: https://github.com/kubernetes/client-go/blob/88ff0afc48bbf242f66f2f0c8d5c26b253e6561c/tools/clientcmd/config.go#L471
-func configFromFile(fileName string) (*clientcmdapi.Config, error) {
-	kubeConfig, err := clientcmd.LoadFromFile(fileName)
-	if err != nil {
-		return nil, err
-	}
-	return kubeConfig, nil
-}
-
-// newContext returns a pointer to a new kubeconfig context with specified cluster and user.
-func newContext(id string, user string) *clientcmdapi.Context {
-	context := clientcmdapi.NewContext()
-	context.Cluster = id
-	context.AuthInfo = user
-
-	return context
-}
-
-// newUser returns a pointer to a new kubeconfig user for a specified cluster.
-// The id given should always be of form "[environment]-[suffix]".
-func newUser(id string, environment string) *clientcmdapi.AuthInfo {
-	user := clientcmdapi.NewAuthInfo()
-
-	// Add exec config.
-	var exec clientcmdapi.ExecConfig
-	exec.Command = "aws-iam-authenticator"
-	exec.APIVersion = "client.authentication.k8s.io/v1alpha1"
-	exec.Args = []string{"token", "-i", id}
-	user.Exec = &exec
-
-	// Add env variables to exec config.
-	var env clientcmdapi.ExecEnvVar
-	env.Name = "AWS_PROFILE"
-	env.Value = environment
-	exec.Env = []clientcmdapi.ExecEnvVar{env}
-
-	return user
-}
-
-// newCluster returns a pointer to a new clientcmdapi.Cluster containing
-// information from a cluster.
-func newCluster(c model.Cluster) *clientcmdapi.Cluster {
-	cluster := clientcmdapi.NewCluster()
-	cluster.Server = c.ServerURL
-	cluster.CertificateAuthorityData = []byte(c.ClusterAuthorityData)
-	return cluster
 }

--- a/pkg/pharos/cli/cli.go
+++ b/pkg/pharos/cli/cli.go
@@ -131,18 +131,20 @@ func GetCluster(id string, kubeConfigFile string, dryRun bool, client *api.Clien
 // ListClusters retrieves all clusters and returns a formatted string
 // of all clusters. If given an environment, ListClusters will only retrieve
 // the clusters for that environment.
-func ListClusters(env string, client *api.Client) (string, error) {
-	var query map[string]string
+func ListClusters(env string, active bool, client *api.Client) (string, error) {
+	query := make(map[string]string)
+	// If active is true, we'll only list active clusters, otherwise we'll list
+	// all clusters, including inactive ones.
+	if active {
+		query["active"] = "true"
+	}
 	if env != "" {
-		query = map[string]string{
-			"active":      "true",
-			"environment": env,
-		}
+		query["environment"] = env
 	}
 
 	c, err := client.ListClusters(query)
 	if err != nil {
-		return "", errors.Wrap(err, "unable to list clusters for specified environment")
+		return "", err
 	}
 
 	// List cluster attributes in organized columns.

--- a/pkg/pharos/cli/cli.go
+++ b/pkg/pharos/cli/cli.go
@@ -150,7 +150,7 @@ func ListClusters(env string, client *api.Client) (string, error) {
 	w := tabwriter.NewWriter(buf, 0, 0, 3, ' ', 0)
 	cyan := color.New(color.FgCyan)
 
-	// Add spaces to prevent ANSI reset codes from breaking the tabwriter formatting.
+	// Add spaces to prevent ANSI escape codes from breaking the tabwriter formatting.
 	_, err = cyan.Fprint(w, "CLUSTER_ID\t     ENVIRONMENT\t     ACTIVE\t     SERVER")
 	if err != nil {
 		return "", err
@@ -160,6 +160,7 @@ func ListClusters(env string, client *api.Client) (string, error) {
 		fmt.Fprintf(w, "\n%s\t%s\t%s\t%s", cluster.ID, cluster.Environment, strconv.FormatBool(cluster.Active), cluster.ServerURL)
 	}
 
+	fmt.Fprintln(w, "")
 	if err := w.Flush(); err != nil {
 		return "", err
 	}

--- a/pkg/pharos/cli/cli.go
+++ b/pkg/pharos/cli/cli.go
@@ -131,11 +131,11 @@ func GetCluster(id string, kubeConfigFile string, dryRun bool, client *api.Clien
 // ListClusters retrieves all clusters and returns a formatted string
 // of all clusters. If given an environment, ListClusters will only retrieve
 // the clusters for that environment.
-func ListClusters(env string, active bool, client *api.Client) (string, error) {
+func ListClusters(env string, inactive bool, client *api.Client) (string, error) {
 	query := make(map[string]string)
-	// If active is true, we'll only list active clusters, otherwise we'll list
+	// If inactive is false, we'll only list active clusters, otherwise we'll list
 	// all clusters, including inactive ones.
-	if active {
+	if !inactive {
 		query["active"] = "true"
 	}
 	if env != "" {

--- a/pkg/pharos/cli/cli_test.go
+++ b/pkg/pharos/cli/cli_test.go
@@ -1,4 +1,4 @@
-package kubeconfig
+package cli
 
 import (
 	"net/http"
@@ -243,6 +243,87 @@ func TestGetCluster(t *testing.T) {
 	})
 }
 
+func TestListClusters(t *testing.T) {
+	// Set up dummy server for testing.
+	listClusters := []byte(`[{
+		"id":                     "production-eggs",
+		"environment":            "production",
+		"cluster_authority_data": "LS0tLS1CRUdJTiBDR...",
+		"server_url":             "https://test.elb.us-west-2.amazonaws.com:6443",
+		"object":                 "cluster",
+		"active":                 false
+	},{
+		"id":                     "sandbox-333333",
+		"environment":            "sandbox",
+		"cluster_authority_data": "LS0tLS1CRUdJTiBDR...",
+		"server_url":             "https://test.elb.us-west-2.amazonaws.com:6443",
+		"object":                 "cluster",
+		"active":                 true
+	},{
+		"id":                     "sandbox-222222",
+		"environment":            "sandbox",
+		"cluster_authority_data": "LS0tLS1CRUdJTiBDR...",
+		"server_url":             "https://test.elb.us-west-2.amazonaws.com:6443",
+		"object":                 "cluster",
+		"active":                 false
+	}]`)
+	listSandbox := []byte(`[{
+		"id":                     "sandbox-333333",
+		"environment":            "sandbox",
+		"cluster_authority_data": "LS0tLS1CRUdJTiBDR...",
+		"server_url":             "https://test.elb.us-west-2.amazonaws.com:6443",
+		"object":                 "cluster",
+		"active":                 true
+	},{
+		"id":                     "sandbox-222222",
+		"environment":            "sandbox",
+		"cluster_authority_data": "LS0tLS1CRUdJTiBDR...",
+		"server_url":             "https://test.elb.us-west-2.amazonaws.com:6443",
+		"object":                 "cluster",
+		"active":                 false
+	}]`)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		var response []byte
+		switch r.URL.String() {
+		case "/clusters":
+			response = listClusters
+		case "/clusters?active=true&environment=sandbox":
+			response = listSandbox
+		}
+		_, err := rw.Write(response)
+		require.NoError(t, err)
+	}))
+	defer srv.Close()
+
+	// Set BaseURL in config to be the url of the dummy server.
+	client := api.NewClient(&configpkg.Config{BaseURL: srv.URL})
+
+	t.Run("successfully lists all clusters", func(tt *testing.T) {
+		// Lists all non-deleted clusters.
+		clusters, err := ListClusters("", client)
+		assert.NoError(tt, err)
+		assert.Contains(tt, clusters, "sandbox-222222")
+		assert.Contains(tt, clusters, "sandbox-333333")
+		assert.Contains(tt, clusters, "production-eggs")
+	})
+
+	t.Run("successfully lists all clusters for an environment", func(tt *testing.T) {
+		// List all clusters for a certain environment.
+		clusters, err := ListClusters("sandbox", client)
+		assert.NoError(tt, err)
+		assert.Contains(tt, clusters, "sandbox-222222")
+		assert.Contains(tt, clusters, "sandbox-333333")
+	})
+
+	t.Run("errors related to retrieving cluster information from the pharos API", func(tt *testing.T) {
+		// Failed to list cluster.
+		_, err := ListClusters("random", client)
+		assert.Error(tt, err)
+		assert.Contains(tt, err.Error(), "unable to list clusters for specified environment")
+	})
+}
+
 func TestSwitchCluster(t *testing.T) {
 	t.Run("successfully switches to cluster", func(tt *testing.T) {
 		// Create temporary test config file and defer cleanup.
@@ -296,25 +377,5 @@ func TestSwitchCluster(t *testing.T) {
 		err := SwitchCluster(nonExistentConfig, "sandbox")
 		assert.Error(tt, err)
 		assert.Contains(tt, err.Error(), "no such file or directory")
-	})
-}
-
-func TestConfigFromFile(t *testing.T) {
-	t.Run("successfully loads from config file", func(tt *testing.T) {
-		kubeConfig, err := configFromFile(config)
-		assert.NoError(tt, err)
-		assert.NotNil(tt, kubeConfig)
-	})
-
-	t.Run("returns empty kubeconfig struct and no error when loading from empty config file", func(tt *testing.T) {
-		kubeConfig, err := configFromFile(emptyConfig)
-		assert.NoError(tt, err)
-		assert.True(tt, reflect.DeepEqual(kubeConfig, clientcmdapi.NewConfig()))
-	})
-
-	t.Run("returns nil and error when loading from nonexistent file", func(tt *testing.T) {
-		kubeConfig, err := configFromFile(nonExistentConfig)
-		assert.Error(tt, err)
-		assert.Nil(tt, kubeConfig)
 	})
 }

--- a/pkg/pharos/cli/cli_test.go
+++ b/pkg/pharos/cli/cli_test.go
@@ -311,7 +311,7 @@ func TestListClusters(t *testing.T) {
 
 	t.Run("successfully lists all clusters", func(tt *testing.T) {
 		// Lists all non-deleted clusters.
-		clusters, err := ListClusters("", false, client)
+		clusters, err := ListClusters("", true, client)
 		assert.NoError(tt, err)
 		assert.Contains(tt, clusters, "sandbox-222222")
 		assert.Contains(tt, clusters, "sandbox-333333")
@@ -320,7 +320,7 @@ func TestListClusters(t *testing.T) {
 
 	t.Run("successfully lists all clusters for an environment", func(tt *testing.T) {
 		// List all clusters for a certain environment.
-		clusters, err := ListClusters("sandbox", false, client)
+		clusters, err := ListClusters("sandbox", true, client)
 		assert.NoError(tt, err)
 		assert.Contains(tt, clusters, "sandbox-222222")
 		assert.Contains(tt, clusters, "sandbox-333333")
@@ -328,7 +328,7 @@ func TestListClusters(t *testing.T) {
 
 	t.Run("successfully lists all active clusters for an environment", func(tt *testing.T) {
 		// List all active clusters for a certain environment.
-		clusters, err := ListClusters("staging", true, client)
+		clusters, err := ListClusters("staging", false, client)
 		assert.NoError(tt, err)
 		assert.Contains(tt, clusters, "staging-555555")
 	})

--- a/pkg/pharos/cli/kubeconfig.go
+++ b/pkg/pharos/cli/kubeconfig.go
@@ -1,0 +1,58 @@
+package cli
+
+import (
+	"github.com/lob/pharos/pkg/util/model"
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+)
+
+// configFromFile returns a struct containing kubeconfig information from a file.
+// Does not differentiate between errors resulting from a missing file and errors
+// from reading from a malformed config.
+// Function source: https://github.com/kubernetes/client-go/blob/88ff0afc48bbf242f66f2f0c8d5c26b253e6561c/tools/clientcmd/config.go#L471
+func configFromFile(fileName string) (*clientcmdapi.Config, error) {
+	kubeConfig, err := clientcmd.LoadFromFile(fileName)
+	if err != nil {
+		return nil, err
+	}
+	return kubeConfig, nil
+}
+
+// newContext returns a pointer to a new kubeconfig context with specified cluster and user.
+func newContext(id string, user string) *clientcmdapi.Context {
+	context := clientcmdapi.NewContext()
+	context.Cluster = id
+	context.AuthInfo = user
+
+	return context
+}
+
+// newUser returns a pointer to a new kubeconfig user for a specified cluster.
+// The id given should always be of form "[environment]-[suffix]".
+func newUser(id string, environment string) *clientcmdapi.AuthInfo {
+	user := clientcmdapi.NewAuthInfo()
+
+	// Add exec config.
+	var exec clientcmdapi.ExecConfig
+	exec.Command = "aws-iam-authenticator"
+	exec.APIVersion = "client.authentication.k8s.io/v1alpha1"
+	exec.Args = []string{"token", "-i", id}
+	user.Exec = &exec
+
+	// Add env variables to exec config.
+	var env clientcmdapi.ExecEnvVar
+	env.Name = "AWS_PROFILE"
+	env.Value = environment
+	exec.Env = []clientcmdapi.ExecEnvVar{env}
+
+	return user
+}
+
+// newCluster returns a pointer to a new clientcmdapi.Cluster containing
+// information from a cluster.
+func newCluster(c model.Cluster) *clientcmdapi.Cluster {
+	cluster := clientcmdapi.NewCluster()
+	cluster.Server = c.ServerURL
+	cluster.CertificateAuthorityData = []byte(c.ClusterAuthorityData)
+	return cluster
+}

--- a/pkg/pharos/cli/kubeconfig_test.go
+++ b/pkg/pharos/cli/kubeconfig_test.go
@@ -1,0 +1,29 @@
+package cli
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+)
+
+func TestConfigFromFile(t *testing.T) {
+	t.Run("successfully loads from config file", func(tt *testing.T) {
+		kubeConfig, err := configFromFile(config)
+		assert.NoError(tt, err)
+		assert.NotNil(tt, kubeConfig)
+	})
+
+	t.Run("returns empty kubeconfig struct and no error when loading from empty config file", func(tt *testing.T) {
+		kubeConfig, err := configFromFile(emptyConfig)
+		assert.NoError(tt, err)
+		assert.True(tt, reflect.DeepEqual(kubeConfig, clientcmdapi.NewConfig()))
+	})
+
+	t.Run("returns nil and error when loading from nonexistent file", func(tt *testing.T) {
+		kubeConfig, err := configFromFile(nonExistentConfig)
+		assert.Error(tt, err)
+		assert.Nil(tt, kubeConfig)
+	})
+}

--- a/pkg/pharos/cmd/current.go
+++ b/pkg/pharos/cmd/current.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/lob/pharos/pkg/pharos/kubeconfig"
+	"github.com/lob/pharos/pkg/pharos/cli"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
@@ -18,7 +18,7 @@ var CurrentCmd = &cobra.Command{
 }
 
 func runCurrent(kubeConfigFile string) error {
-	clusterName, err := kubeconfig.CurrentCluster(kubeConfigFile)
+	clusterName, err := cli.CurrentCluster(kubeConfigFile)
 	if err != nil {
 		return errors.Wrap(err, "unable to retrieve cluster")
 	}

--- a/pkg/pharos/cmd/get.go
+++ b/pkg/pharos/cmd/get.go
@@ -5,7 +5,7 @@ import (
 	"os"
 
 	"github.com/lob/pharos/pkg/pharos/api"
-	"github.com/lob/pharos/pkg/pharos/kubeconfig"
+	"github.com/lob/pharos/pkg/pharos/cli"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
@@ -30,7 +30,7 @@ var GetCmd = &cobra.Command{
 }
 
 func runGet(cluster string, kubeConfigFile string, dryRun bool, client *api.Client) error {
-	err := kubeconfig.GetCluster(cluster, kubeConfigFile, dryRun, client)
+	err := cli.GetCluster(cluster, kubeConfigFile, dryRun, client)
 	if err != nil {
 		return errors.Wrap(err, "failed to get cluster information")
 	}

--- a/pkg/pharos/cmd/get_test.go
+++ b/pkg/pharos/cmd/get_test.go
@@ -7,8 +7,8 @@ import (
 	"testing"
 
 	"github.com/lob/pharos/pkg/pharos/api"
+	"github.com/lob/pharos/pkg/pharos/cli"
 	configpkg "github.com/lob/pharos/pkg/pharos/config"
-	"github.com/lob/pharos/pkg/pharos/kubeconfig"
 	"github.com/lob/pharos/pkg/util/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -43,14 +43,14 @@ func TestRunGet(t *testing.T) {
 		assert.NoError(tt, err)
 
 		// Check that current context has not been modified.
-		clusterName, err := kubeconfig.CurrentCluster(configFile)
+		clusterName, err := cli.CurrentCluster(configFile)
 		assert.NoError(tt, err)
 		assert.Equal(tt, "sandbox", clusterName)
 
 		// Check that a new cluster was added by switching to it and checking whether the switch was successful.
 		err = runSwitch(configFile, "sandbox-161616")
 		assert.NoError(tt, err)
-		clusterName, err = kubeconfig.CurrentCluster(configFile)
+		clusterName, err = cli.CurrentCluster(configFile)
 		assert.NoError(tt, err)
 		assert.Equal(tt, "sandbox-161616", clusterName)
 	})

--- a/pkg/pharos/cmd/list.go
+++ b/pkg/pharos/cmd/list.go
@@ -11,6 +11,7 @@ import (
 
 // Declare some variables to be used as flags.
 var environment string
+var inactive bool
 
 // ListCmd implements a CLI command that allows users to retrieve a list of all clusters
 // currently registered with pharos-api.
@@ -23,12 +24,12 @@ var ListCmd = &cobra.Command{
 		if err != nil {
 			return errors.Wrap(err, "unable to create client from pharos config file")
 		}
-		return runList(environment, active, client)
+		return runList(environment, inactive, client)
 	},
 }
 
-func runList(env string, active bool, client *api.Client) error {
-	clusters, err := cli.ListClusters(environment, active, client)
+func runList(env string, inactive bool, client *api.Client) error {
+	clusters, err := cli.ListClusters(environment, inactive, client)
 	if err != nil {
 		return errors.Wrap(err, "failed to list clusters")
 	}
@@ -38,5 +39,5 @@ func runList(env string, active bool, client *api.Client) error {
 
 func init() {
 	ListCmd.Flags().StringVarP(&environment, "environment", "e", "", "specify environment to list clusters for")
-	ListCmd.Flags().BoolVarP(&active, "active", "a", true, "status of clusters to list")
+	ListCmd.Flags().BoolVarP(&inactive, "inactive", "i", false, "specify whether to list inactive clusters")
 }

--- a/pkg/pharos/cmd/list.go
+++ b/pkg/pharos/cmd/list.go
@@ -32,7 +32,7 @@ func runList(env string, client *api.Client) error {
 	if err != nil {
 		return errors.Wrap(err, "failed to list clusters")
 	}
-	fmt.Println(clusters)
+	fmt.Print(clusters)
 	return nil
 }
 

--- a/pkg/pharos/cmd/list.go
+++ b/pkg/pharos/cmd/list.go
@@ -1,0 +1,41 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/lob/pharos/pkg/pharos/api"
+	"github.com/lob/pharos/pkg/pharos/cli"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+)
+
+// Declare some variables to be used as flags.
+var environment string
+
+// ListCmd implements a CLI command that allows users to retrieve a list of all clusters
+// currently registered with pharos-api.
+var ListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "Retrieves a list of all clusters.",
+	Long:  "Retrieves a list of all clusters currently registered with Pharos.",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := api.ClientFromConfig(pharosConfig)
+		if err != nil {
+			return errors.Wrap(err, "unable to create client from pharos config file")
+		}
+		return runList(environment, client)
+	},
+}
+
+func runList(env string, client *api.Client) error {
+	clusters, err := cli.ListClusters(environment, client)
+	if err != nil {
+		return errors.Wrap(err, "failed to list clusters")
+	}
+	fmt.Println(clusters)
+	return nil
+}
+
+func init() {
+	ListCmd.Flags().StringVarP(&environment, "environment", "e", "", "specify environment to list clusters for")
+}

--- a/pkg/pharos/cmd/list.go
+++ b/pkg/pharos/cmd/list.go
@@ -23,12 +23,12 @@ var ListCmd = &cobra.Command{
 		if err != nil {
 			return errors.Wrap(err, "unable to create client from pharos config file")
 		}
-		return runList(environment, client)
+		return runList(environment, active, client)
 	},
 }
 
-func runList(env string, client *api.Client) error {
-	clusters, err := cli.ListClusters(environment, client)
+func runList(env string, active bool, client *api.Client) error {
+	clusters, err := cli.ListClusters(environment, active, client)
 	if err != nil {
 		return errors.Wrap(err, "failed to list clusters")
 	}
@@ -38,4 +38,5 @@ func runList(env string, client *api.Client) error {
 
 func init() {
 	ListCmd.Flags().StringVarP(&environment, "environment", "e", "", "specify environment to list clusters for")
+	ListCmd.Flags().BoolVarP(&active, "active", "a", true, "status of clusters to list")
 }

--- a/pkg/pharos/cmd/list.go
+++ b/pkg/pharos/cmd/list.go
@@ -39,5 +39,5 @@ func runList(env string, inactive bool, client *api.Client) error {
 
 func init() {
 	ListCmd.Flags().StringVarP(&environment, "environment", "e", "", "specify environment to list clusters for")
-	ListCmd.Flags().BoolVarP(&inactive, "inactive", "i", false, "specify whether to list inactive clusters")
+	ListCmd.Flags().BoolVarP(&inactive, "inactive", "i", false, "specify whether to include inactive clusters in the list")
 }

--- a/pkg/pharos/cmd/list_test.go
+++ b/pkg/pharos/cmd/list_test.go
@@ -1,0 +1,59 @@
+package cmd
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/lob/pharos/pkg/pharos/api"
+	configpkg "github.com/lob/pharos/pkg/pharos/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRunList(t *testing.T) {
+	t.Run("successfully lists information about clusters", func(tt *testing.T) {
+		// Set up dummy server for testing.
+		var listSandboxClusters = []byte(`[{
+			"id":                     "sandbox-333333",
+			"environment":            "sandbox",
+			"cluster_authority_data": "LS0tLS1CRUdJTiBDR...",
+			"server_url":             "https://test.elb.us-west-2.amazonaws.com:6443",
+			"object":                 "cluster",
+			"active":                 true
+		}, {
+			"id":                     "sandbox-222222",
+			"environment":            "sandbox",
+			"cluster_authority_data": "LS0tLS1CRUdJTiBDR...",
+			"server_url":             "https://test.elb.us-west-2.amazonaws.com:6443",
+			"object":                 "cluster",
+			"active":                 false
+		}]`)
+
+		srv := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+			_, err := rw.Write(listSandboxClusters)
+			require.NoError(tt, err)
+		}))
+		defer srv.Close()
+		// Set BaseURL in config to be the url of the dummy server.
+		client := api.NewClient(&configpkg.Config{BaseURL: srv.URL})
+
+		err := runList("sandbox", client)
+		assert.NoError(tt, err)
+	})
+
+	t.Run("errors when the api server fails to respond with clusters", func(tt *testing.T) {
+		// Set up dummy server for testing.
+		srv := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+			_, err := rw.Write([]byte(`{}`))
+			require.NoError(tt, err)
+		}))
+		defer srv.Close()
+
+		// Set BaseURL in config to be the url of the dummy server.
+		client := api.NewClient(&configpkg.Config{BaseURL: srv.URL})
+
+		err := runList("", client)
+		assert.Error(tt, err)
+	})
+}

--- a/pkg/pharos/cmd/list_test.go
+++ b/pkg/pharos/cmd/list_test.go
@@ -38,7 +38,7 @@ func TestRunList(t *testing.T) {
 		// Set BaseURL in config to be the url of the dummy server.
 		client := api.NewClient(&configpkg.Config{BaseURL: srv.URL})
 
-		err := runList("sandbox", client)
+		err := runList("sandbox", false, client)
 		assert.NoError(tt, err)
 	})
 
@@ -53,7 +53,7 @@ func TestRunList(t *testing.T) {
 		// Set BaseURL in config to be the url of the dummy server.
 		client := api.NewClient(&configpkg.Config{BaseURL: srv.URL})
 
-		err := runList("", client)
+		err := runList("", false, client)
 		assert.Error(tt, err)
 	})
 }

--- a/pkg/pharos/cmd/list_test.go
+++ b/pkg/pharos/cmd/list_test.go
@@ -38,7 +38,7 @@ func TestRunList(t *testing.T) {
 		// Set BaseURL in config to be the url of the dummy server.
 		client := api.NewClient(&configpkg.Config{BaseURL: srv.URL})
 
-		err := runList("sandbox", false, client)
+		err := runList("sandbox", true, client)
 		assert.NoError(tt, err)
 	})
 
@@ -53,7 +53,7 @@ func TestRunList(t *testing.T) {
 		// Set BaseURL in config to be the url of the dummy server.
 		client := api.NewClient(&configpkg.Config{BaseURL: srv.URL})
 
-		err := runList("", false, client)
+		err := runList("", true, client)
 		assert.Error(tt, err)
 	})
 }

--- a/pkg/pharos/cmd/root.go
+++ b/pkg/pharos/cmd/root.go
@@ -11,6 +11,7 @@ import (
 // Declare some variables to be used as flags in various commands.
 var file string
 var pharosConfig string
+var active bool
 
 // rootCmd represents the base command when called without any subcommands.
 var rootCmd = &cobra.Command{

--- a/pkg/pharos/cmd/root.go
+++ b/pkg/pharos/cmd/root.go
@@ -11,7 +11,6 @@ import (
 // Declare some variables to be used as flags in various commands.
 var file string
 var pharosConfig string
-var active bool
 
 // rootCmd represents the base command when called without any subcommands.
 var rootCmd = &cobra.Command{

--- a/pkg/pharos/cmd/root.go
+++ b/pkg/pharos/cmd/root.go
@@ -41,6 +41,7 @@ func init() {
 	clustersCmd.AddCommand(CurrentCmd)
 	clustersCmd.AddCommand(SwitchCmd)
 	clustersCmd.AddCommand(GetCmd)
+	clustersCmd.AddCommand(ListCmd)
 }
 
 // argID prevents commands from being run unless exactly one argument (a cluster name or id)

--- a/pkg/pharos/cmd/switch.go
+++ b/pkg/pharos/cmd/switch.go
@@ -4,7 +4,8 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/lob/pharos/pkg/pharos/kubeconfig"
+	"github.com/fatih/color"
+	"github.com/lob/pharos/pkg/pharos/cli"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
@@ -21,12 +22,12 @@ var SwitchCmd = &cobra.Command{
 func runSwitch(kubeConfigFile string, context string) error {
 	fmt.Printf("SWITCHING TO CLUSTER %s...\n", context)
 
-	err := kubeconfig.SwitchCluster(kubeConfigFile, context)
+	err := cli.SwitchCluster(kubeConfigFile, context)
 	if err != nil {
 		return errors.Wrap(err, "cluster switch unsuccessful")
 	}
 
-	fmt.Println("CLUSTER SWITCH COMPLETE.")
+	fmt.Printf("%s CLUSTER SWITCH COMPLETE\n", color.GreenString("SUCCESS:"))
 	return nil
 }
 

--- a/pkg/pharos/cmd/switch_test.go
+++ b/pkg/pharos/cmd/switch_test.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/lob/pharos/pkg/pharos/kubeconfig"
+	"github.com/lob/pharos/pkg/pharos/cli"
 	"github.com/lob/pharos/pkg/util/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -21,7 +21,7 @@ func TestRunSwitch(t *testing.T) {
 		require.NoError(tt, err)
 
 		// Check that switch was successful.
-		clusterName, err := kubeconfig.CurrentCluster(configFile)
+		clusterName, err := cli.CurrentCluster(configFile)
 		require.NoError(tt, err)
 		require.Equal(tt, "sandbox-111111", clusterName)
 	})


### PR DESCRIPTION
### what & why
- adds `pharos clusters list` command to retrieve a list of all non-deleted clusters from pharos
- adds color to cli command output (also adds colors to some get/switch command outputs)
- refactors the kubeconfig package into the cli package, since files were getting very long

### notes
- I couldn't test the environment variable usage locally since the list clusters query functionality has not yet been added

### testing the cli locally
![image](https://user-images.githubusercontent.com/10638317/60053040-bc94ce00-968b-11e9-81e5-90d65e76609a.png)
colored output:
![image](https://user-images.githubusercontent.com/10638317/60053281-4f356d00-968c-11e9-912b-c697d4c624b7.png)
