### PR TITLE
feat(cli): add pharos clusters sync command

### DIFF
--- a/pkg/pharos/cli/cli.go
+++ b/pkg/pharos/cli/cli.go
@@ -195,10 +195,9 @@ func SwitchCluster(kubeConfigFile string, context string) error {
 
 // SyncClusters gets information from clusters and merges it into a kubeconfig file.
 func SyncClusters(kubeConfigFile string, inactive bool, dryRun bool, overwrite bool, client *api.Client) error {
-	var (
-		kubeConfig *clientcmdapi.Config
-		err        error
-	)
+	var kubeConfig *clientcmdapi.Config
+	var err error
+
 	if !overwrite {
 		// Check whether given kubeconfig file already exists. If it does not, create a new kubeconfig
 		// file in the specified file location. Return an error only if file is malformed, but not

--- a/pkg/pharos/cli/cli_test.go
+++ b/pkg/pharos/cli/cli_test.go
@@ -620,7 +620,6 @@ func TestSyncClusters(t *testing.T) {
 		// Check that there were no inactive clusters added.
 		_, ok = kubeConfig.Clusters["staging-555555"]
 		assert.False(tt, ok)
-
 	})
 
 	t.Run("takes no action when --dry-run flag is set", func(tt *testing.T) {

--- a/pkg/pharos/cli/cli_test.go
+++ b/pkg/pharos/cli/cli_test.go
@@ -398,3 +398,203 @@ func TestSwitchCluster(t *testing.T) {
 		assert.Contains(tt, err.Error(), "no such file or directory")
 	})
 }
+
+func TestSyncClusters(t *testing.T) {
+	// Set up dummy server for testing.
+	syncResponse := []byte(`[{
+		"id":                     "sandbox-333333",
+		"environment":            "sandbox",
+		"cluster_authority_data": "LS0tLS1CRUdJTiBDR...",
+		"server_url":             "https://test.elb.us-west-2.amazonaws.com:6443",
+		"object":                 "cluster",
+		"active":                 false
+	}, {
+		"id":                     "sandbox-444444",
+		"environment":            "sandbox",
+		"cluster_authority_data": "LS0tLS1CRUdJTiBDR...",
+		"server_url":             "https://test.elb.us-west-2.amazonaws.com:6443",
+		"object":                 "cluster",
+		"active":                 true
+	}, {
+		"id":                     "core-111111",
+		"environment":            "core",
+		"cluster_authority_data": "LS0tLS1CRUdJTiBDR...",
+		"server_url":             "https://test.com",
+		"object":                 "cluster",
+		"active":                 true
+	}, {
+		"id":                     "staging-555555",
+		"environment":            "staging",
+		"cluster_authority_data": "LS0tLS1CRUdJTiBDR...",
+		"server_url":             "https://test.elb.us-west-2.amazonaws.com:6443",
+		"object":                 "cluster",
+		"active":                 false
+	}, {
+		"id":                     "staging-666666",
+		"environment":            "staging",
+		"cluster_authority_data": "LS0tLS1CRUdJTiBDR...",
+		"server_url":             "https://test.elb.us-west-2.amazonaws.com:6443",
+		"object":                 "cluster",
+		"active":                 true
+	}]`)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		_, err := rw.Write(syncResponse)
+		require.NoError(t, err)
+	}))
+	defer srv.Close()
+	tokenGenerator := test.NewGenerator()
+
+	// Set BaseURL in config to be the url of the dummy server.
+	client := api.NewClient(&configpkg.Config{BaseURL: srv.URL}, tokenGenerator)
+
+	t.Run("successfully merges kubeconfig file from syncing clusters into existing kubeconfig", func(tt *testing.T) {
+		// Create temporary test config file and defer cleanup.
+		configFile := test.CopyTestFile(tt, "../testdata", "sync", config)
+		defer os.Remove(configFile)
+
+		// Merge cluster information from active cluster for sandbox into configFile.
+		err := SyncClusters(configFile, false, false, client)
+		assert.NoError(tt, err)
+
+		// Load kubeconfig file for testing.
+		kubeConfig, err := configFromFile(configFile)
+		assert.NoError(tt, err)
+
+		// Load old kubeconfig file for comparison.
+		oldKubeConfig, err := configFromFile(config)
+		assert.NoError(tt, err)
+
+		// Check that context for sandbox has been updated.
+		context, ok := kubeConfig.Contexts["sandbox"]
+		assert.True(tt, ok)
+		assert.Equal(tt, context.Cluster, "sandbox-444444")
+		assert.Equal(tt, context.AuthInfo, "iam-sandbox-444444")
+
+		// Check that context for the sandbox cluster exists in the file.
+		context, ok = kubeConfig.Contexts["sandbox-333333"]
+		assert.True(tt, ok)
+		assert.Equal(tt, context.Cluster, "sandbox-333333")
+		assert.Equal(tt, context.AuthInfo, "iam-sandbox-333333")
+
+		// Check that contexts for other clusters were added.
+		_, ok = kubeConfig.Contexts["core"]
+		assert.True(tt, ok)
+		_, ok = kubeConfig.Contexts["core-111111"]
+		assert.True(tt, ok)
+		context, ok = kubeConfig.Contexts["staging"]
+		assert.True(tt, ok)
+		assert.Equal(tt, context.Cluster, "staging-666666")
+		assert.Equal(tt, context.AuthInfo, "iam-staging-666666")
+		_, ok = kubeConfig.Contexts["staging-555555"]
+		assert.True(tt, ok)
+
+		// Check that new users were created for all new clusters.
+		_, ok = kubeConfig.AuthInfos["iam-sandbox-333333"]
+		assert.True(tt, ok)
+		_, ok = kubeConfig.AuthInfos["iam-sandbox-444444"]
+		assert.True(tt, ok)
+		_, ok = kubeConfig.AuthInfos["iam-core-111111"]
+		assert.True(tt, ok)
+		_, ok = kubeConfig.AuthInfos["iam-staging-555555"]
+		assert.True(tt, ok)
+
+		// Check that old clusters and contexts still exist in file.
+		_, ok = kubeConfig.Clusters["sandbox-111111"]
+		assert.True(tt, ok)
+		_, ok = kubeConfig.Contexts["sandbox-111111"]
+		assert.True(tt, ok)
+
+		// Check that current context has not been modified.
+		assert.Equal(tt, kubeConfig.CurrentContext, oldKubeConfig.CurrentContext)
+	})
+
+	t.Run("successfully overwrites existing kubeconfig using when --overwrite flag is set to true", func(tt *testing.T) {
+		// Create temporary test config file and defer cleanup.
+		configFile := test.CopyTestFile(tt, "../testdata", "sync", config)
+		defer os.Remove(configFile)
+
+		// Merge cluster information from active cluster for sandbox into configFile.
+		err := SyncClusters(configFile, false, true, client)
+		assert.NoError(tt, err)
+
+		// Load kubeconfig file for testing.
+		kubeConfig, err := configFromFile(configFile)
+		assert.NoError(tt, err)
+
+		// Check that context for sandbox has been updated.
+		context, ok := kubeConfig.Contexts["sandbox"]
+		assert.True(tt, ok)
+		assert.Equal(tt, context.Cluster, "sandbox-444444")
+		assert.Equal(tt, context.AuthInfo, "iam-sandbox-444444")
+
+		// Check that context and clusters for old clusters no longer exists in the file.
+		_, ok = kubeConfig.Clusters["sandbox-111111"]
+		assert.False(tt, ok)
+		_, ok = kubeConfig.Contexts["sandbox-111111"]
+		assert.False(tt, ok)
+	})
+
+	t.Run("successfully creates new kubeconfig file from syncing clusters", func(tt *testing.T) {
+		// Create temporary test config file and defer cleanup.
+		nonExistentConfig := "../testdata/nonexistentFile"
+		defer os.Remove(nonExistentConfig)
+
+		// Merge cluster information from active cluster for sandbox into configFile.
+		err := SyncClusters(nonExistentConfig, false, false, client)
+		assert.NoError(tt, err)
+
+		// Load kubeconfig file for testing.
+		kubeConfig, err := configFromFile(nonExistentConfig)
+		assert.NoError(tt, err)
+
+		// Check that contexts for clusters were added.
+		_, ok := kubeConfig.Contexts["core"]
+		assert.True(tt, ok)
+		_, ok = kubeConfig.Contexts["core-111111"]
+		assert.True(tt, ok)
+		context, ok := kubeConfig.Contexts["staging"]
+		assert.True(tt, ok)
+		assert.Equal(tt, context.Cluster, "staging-666666")
+		assert.Equal(tt, context.AuthInfo, "iam-staging-666666")
+		_, ok = kubeConfig.Contexts["staging-555555"]
+		assert.True(tt, ok)
+
+		// Check that new users were created for all new clusters.
+		_, ok = kubeConfig.AuthInfos["iam-sandbox-333333"]
+		assert.True(tt, ok)
+		_, ok = kubeConfig.AuthInfos["iam-sandbox-444444"]
+		assert.True(tt, ok)
+		_, ok = kubeConfig.AuthInfos["iam-core-111111"]
+		assert.True(tt, ok)
+		_, ok = kubeConfig.AuthInfos["iam-staging-666666"]
+		assert.True(tt, ok)
+	})
+
+	t.Run("takes no action when --dry-run flag is set", func(tt *testing.T) {
+		oldKubeConfig, err := configFromFile(config)
+		assert.NoError(tt, err)
+
+		// Run get cluster with dry-run.
+		err = SyncClusters(config, true, false, client)
+		assert.NoError(tt, err)
+
+		// Check that kubeconfig file has not been modified.
+		kubeConfig, err := configFromFile(config)
+		assert.NoError(tt, err)
+		assert.True(tt, reflect.DeepEqual(oldKubeConfig, kubeConfig))
+	})
+
+	t.Run("errors on merging with malformed kubeconfig file", func(tt *testing.T) {
+		err := SyncClusters(malformedConfig, true, false, client)
+		assert.Error(tt, err)
+		assert.Contains(tt, err.Error(), "unable to load kubeconfig file")
+	})
+
+	t.Run("errors related to retrieving cluster information from the pharos API", func(tt *testing.T) {
+		// Failed to list cluster.
+		err := SyncClusters(config, false, false, api.NewClient(&configpkg.Config{BaseURL: ""}, tokenGenerator))
+		assert.Error(tt, err)
+		assert.Contains(tt, err.Error(), "failed to list clusters")
+	})
+}

--- a/pkg/pharos/cmd/delete.go
+++ b/pkg/pharos/cmd/delete.go
@@ -13,7 +13,7 @@ import (
 // as deleted in the Pharos database.
 var DeleteCmd = &cobra.Command{
 	Use:   "delete <cluster_id>",
-	Short: "Deletes the specified cluster.",
+	Short: "Deletes the specified cluster",
 	Long:  "Marks the specified cluster as deleted in Pharos.",
 	Args:  func(cmd *cobra.Command, args []string) error { return argID(args) },
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/pkg/pharos/cmd/get.go
+++ b/pkg/pharos/cmd/get.go
@@ -10,9 +10,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// Declare some variables to be used as flags.
-var dryRun bool
-
 // GetCmd implements a CLI command that allows users to get cluster information from a new cluster
 // and merge it into an existing kubeconfig file.
 var GetCmd = &cobra.Command{

--- a/pkg/pharos/cmd/list.go
+++ b/pkg/pharos/cmd/list.go
@@ -9,9 +9,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// Declare some variables to be used as flags.
+// Declare a variable to be used as a flag.
 var environment string
-var inactive bool
 
 // ListCmd implements a CLI command that allows users to retrieve a list of all clusters
 // currently registered with pharos-api.

--- a/pkg/pharos/cmd/root.go
+++ b/pkg/pharos/cmd/root.go
@@ -10,6 +10,7 @@ import (
 
 // Declare some variables to be used as flags in various commands.
 var file string
+var dryRun bool
 var pharosConfig string
 
 // rootCmd represents the base command when called without any subcommands.
@@ -43,6 +44,7 @@ func init() {
 	clustersCmd.AddCommand(GetCmd)
 	clustersCmd.AddCommand(ListCmd)
 	clustersCmd.AddCommand(SwitchCmd)
+	clustersCmd.AddCommand(SyncCmd)
 	clustersCmd.AddCommand(UpdateCmd)
 }
 

--- a/pkg/pharos/cmd/root.go
+++ b/pkg/pharos/cmd/root.go
@@ -12,6 +12,7 @@ import (
 var file string
 var dryRun bool
 var pharosConfig string
+var inactive bool
 
 // rootCmd represents the base command when called without any subcommands.
 var rootCmd = &cobra.Command{

--- a/pkg/pharos/cmd/root.go
+++ b/pkg/pharos/cmd/root.go
@@ -9,10 +9,12 @@ import (
 )
 
 // Declare some variables to be used as flags in various commands.
-var file string
-var dryRun bool
-var pharosConfig string
-var inactive bool
+var (
+	file         string
+	dryRun       bool
+	pharosConfig string
+	inactive     bool
+)
 
 // rootCmd represents the base command when called without any subcommands.
 var rootCmd = &cobra.Command{

--- a/pkg/pharos/cmd/sync.go
+++ b/pkg/pharos/cmd/sync.go
@@ -1,0 +1,43 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/lob/pharos/pkg/pharos/api"
+	"github.com/lob/pharos/pkg/pharos/cli"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+)
+
+// Declare variable to be used as a flag.
+var overwrite bool
+
+// SyncCmd implements a CLI command that allows users to get cluster information
+// from all currently existing clusters in Pharos and merge it into an existing kubeconfig file.
+var SyncCmd = &cobra.Command{
+	Use:   "sync",
+	Short: "Retrieves information from all clusters",
+	Long:  "Retrieves information from all clusters and merges it into designated kubeconfig file.",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := api.ClientFromConfig(pharosConfig)
+		if err != nil {
+			return errors.Wrap(err, "unable to create client from pharos config file")
+		}
+		return runSync(file, dryRun, overwrite, client)
+	},
+}
+
+func runSync(kubeConfigFile string, dryRun bool, overwrite bool, client *api.Client) error {
+	err := cli.SyncClusters(kubeConfigFile, dryRun, overwrite, client)
+	if err != nil {
+		return errors.Wrap(err, "failed to sync clusters")
+	}
+	return nil
+}
+
+func init() {
+	SyncCmd.Flags().BoolVarP(&dryRun, "dry-run", "d", false, "prints the resulting kubeconfig to terminal without any other action")
+	SyncCmd.Flags().BoolVarP(&overwrite, "overwrite", "o", false, "overwrite the kubeconfig file with retrieved clusters")
+	SyncCmd.Flags().StringVarP(&file, "file", "f", fmt.Sprintf("%s/.kube/config", os.Getenv("HOME")), "specify kubeconfig file to merge into")
+}

--- a/pkg/pharos/cmd/sync.go
+++ b/pkg/pharos/cmd/sync.go
@@ -17,19 +17,19 @@ var overwrite bool
 // from all currently existing clusters in Pharos and merge it into an existing kubeconfig file.
 var SyncCmd = &cobra.Command{
 	Use:   "sync",
-	Short: "Retrieves information from all clusters",
-	Long:  "Retrieves information from all clusters and merges it into designated kubeconfig file.",
+	Short: "Retrieves information from clusters",
+	Long:  "Retrieves information from specified clusters and merges it into designated kubeconfig file.",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		client, err := api.ClientFromConfig(pharosConfig)
 		if err != nil {
 			return errors.Wrap(err, "unable to create client from pharos config file")
 		}
-		return runSync(file, dryRun, overwrite, client)
+		return runSync(file, inactive, dryRun, overwrite, client)
 	},
 }
 
-func runSync(kubeConfigFile string, dryRun bool, overwrite bool, client *api.Client) error {
-	err := cli.SyncClusters(kubeConfigFile, dryRun, overwrite, client)
+func runSync(kubeConfigFile string, inactive bool, dryRun bool, overwrite bool, client *api.Client) error {
+	err := cli.SyncClusters(kubeConfigFile, inactive, dryRun, overwrite, client)
 	if err != nil {
 		return errors.Wrap(err, "failed to sync clusters")
 	}
@@ -37,6 +37,7 @@ func runSync(kubeConfigFile string, dryRun bool, overwrite bool, client *api.Cli
 }
 
 func init() {
+	SyncCmd.Flags().BoolVarP(&inactive, "inactive", "i", false, "specify whether to sync inactive clusters")
 	SyncCmd.Flags().BoolVarP(&dryRun, "dry-run", "d", false, "prints the resulting kubeconfig to terminal without any other action")
 	SyncCmd.Flags().BoolVarP(&overwrite, "overwrite", "o", false, "overwrite the kubeconfig file with retrieved clusters")
 	SyncCmd.Flags().StringVarP(&file, "file", "f", fmt.Sprintf("%s/.kube/config", os.Getenv("HOME")), "specify kubeconfig file to merge into")

--- a/pkg/pharos/cmd/sync_test.go
+++ b/pkg/pharos/cmd/sync_test.go
@@ -47,7 +47,7 @@ func TestRunSync(t *testing.T) {
 		defer os.Remove(configFile)
 
 		// Merge cluster information from active cluster for sandbox into configFile.
-		err := runSync(configFile, false, false, client)
+		err := runSync(configFile, false, false, false, client)
 		assert.NoError(tt, err)
 
 		// Check that current context has not been modified.
@@ -76,7 +76,7 @@ func TestRunSync(t *testing.T) {
 		client := api.NewClient(&configpkg.Config{BaseURL: srv.URL}, tokenGenerator)
 
 		// Attempt to merge new cluster into configFile but this should fail because no cluster has been returned.
-		err := runSync(config, false, false, client)
+		err := runSync(config, false, false, false, client)
 		assert.Error(tt, err)
 		assert.Contains(tt, err.Error(), "failed to sync clusters")
 	})

--- a/pkg/pharos/cmd/sync_test.go
+++ b/pkg/pharos/cmd/sync_test.go
@@ -1,0 +1,83 @@
+package cmd
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/lob/pharos/internal/test"
+	"github.com/lob/pharos/pkg/pharos/api"
+	"github.com/lob/pharos/pkg/pharos/cli"
+	configpkg "github.com/lob/pharos/pkg/pharos/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRunSync(t *testing.T) {
+	t.Run("successfully merges information from a cluster into a kubeconfig file", func(tt *testing.T) {
+		// Set up dummy server for testing.
+		testResponse := []byte(`[{
+			"id":                     "staging-555555",
+			"environment":            "staging",
+			"cluster_authority_data": "LS0tLS1CRUdJTiBDR...",
+			"server_url":             "https://test.elb.us-west-2.amazonaws.com:6443",
+			"object":                 "cluster",
+			"active":                 false
+		}, {
+			"id":                     "staging-666666",
+			"environment":            "staging",
+			"cluster_authority_data": "LS0tLS1CRUdJTiBDR...",
+			"server_url":             "https://test.elb.us-west-2.amazonaws.com:6443",
+			"object":                 "cluster",
+			"active":                 true
+		}]`)
+		srv := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+			_, err := rw.Write(testResponse)
+			require.NoError(tt, err)
+		}))
+		defer srv.Close()
+		tokenGenerator := test.NewGenerator()
+
+		// Set BaseURL in config to be the url of the dummy server.
+		client := api.NewClient(&configpkg.Config{BaseURL: srv.URL}, tokenGenerator)
+
+		// Create temporary test config file and defer cleanup.
+		configFile := test.CopyTestFile(tt, "../testdata", "get", config)
+		defer os.Remove(configFile)
+
+		// Merge cluster information from active cluster for sandbox into configFile.
+		err := runSync(configFile, false, false, client)
+		assert.NoError(tt, err)
+
+		// Check that current context has not been modified.
+		clusterName, err := cli.CurrentCluster(configFile)
+		assert.NoError(tt, err)
+		assert.Equal(tt, "sandbox", clusterName)
+
+		// Check that a new context for staging was added by switching to it and checking whether the switch was successful.
+		err = runSwitch(configFile, "staging")
+		assert.NoError(tt, err)
+		clusterName, err = cli.CurrentCluster(configFile)
+		assert.NoError(tt, err)
+		assert.Equal(tt, "staging", clusterName)
+	})
+
+	t.Run("errors when the api server fails to respond with a cluster", func(tt *testing.T) {
+		// Set up dummy server for testing.
+		srv := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+			_, err := rw.Write([]byte(`{}`))
+			require.NoError(tt, err)
+		}))
+		defer srv.Close()
+		tokenGenerator := test.NewGenerator()
+
+		// Set BaseURL in config to be the url of the dummy server.
+		client := api.NewClient(&configpkg.Config{BaseURL: srv.URL}, tokenGenerator)
+
+		// Attempt to merge new cluster into configFile but this should fail because no cluster has been returned.
+		err := runSync(config, false, false, client)
+		assert.Error(tt, err)
+		assert.Contains(tt, err.Error(), "failed to sync clusters")
+	})
+}


### PR DESCRIPTION
### what & why
- adds `pharos clusters sync` command to pharos

### notes
- when overwriting or creating a new kubeconfig file, the sync command does NOT set a current context
- the overwrite flag is something i added ad-hoc, but i figured it would be useful if anyone ever needed to mass delete deleted clusters from their kubeconfig files/update their kubeconfig files
- the inactive flag is similar to the list command's flag - by default only active clusters will be synced

### testing the CLI locally
![image](https://user-images.githubusercontent.com/10638317/60287659-48466e80-98c7-11e9-8870-9e0415a77dbc.png)