### PR TITLE
feat(authentication): add authentication middleware

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -10,7 +10,7 @@
   version = "2.2.0"
 
 [[projects]]
-  digest = "1:898b54728c29582198dc5a518630db42ad4012c63e7295a8fb5bec9652ec3082"
+  digest = "1:c35939432de12624b062756e5fd08b408e642255c0a55748ae990bb65092488b"
   name = "github.com/aws/aws-sdk-go"
   packages = [
     "aws",
@@ -36,8 +36,8 @@
     "service/sts/stsiface",
   ]
   pruneopts = "UT"
-  revision = "b9b2c2cd61a6814e3cd5d07e4c200dac18b357a4"
-  version = "v1.19.49"
+  revision = "e46d74c7f7fbfb66376097b38e466ab031864764"
+  version = "v1.20.8"
 
 [[projects]]
   digest = "1:fed1f537c2f1269fe475a8556c393fe466641682d73ef8fd0491cd3aa1e47bad"
@@ -56,12 +56,12 @@
   version = "v1.1.1"
 
 [[projects]]
-  digest = "1:938a2672d6ebbb7f7bc63eee3e4b9464c16ffcf77ec8913d3edbf32b4e3984dd"
+  digest = "1:865079840386857c809b72ce300be7580cb50d3d3129ce11bf9aa6ca2bc1934a"
   name = "github.com/fatih/color"
   packages = ["."]
   pruneopts = "UT"
-  revision = "570b54cabe6b8eb0bc2dfce68d964677d63b5260"
-  version = "v1.5.0"
+  revision = "5b77d2a35fb0ede96d138fc9a99f5c9b6aef11b4"
+  version = "v1.7.0"
 
 [[projects]]
   digest = "1:d18f6f088d7d8365df47f49dfa24b6ff6701a941118ffda30c589d1bd954074b"
@@ -160,12 +160,12 @@
   version = "v1.0"
 
 [[projects]]
-  branch = "master"
   digest = "1:01ed62f8f4f574d8aff1d88caee113700a2b44c42351943fa73cc1808f736a50"
   name = "github.com/jinzhu/inflection"
   packages = ["."]
   pruneopts = "UT"
   revision = "f5c5f50e6090ae76a29240b61ae2a90dd810112e"
+  version = "v1.0.0"
 
 [[projects]]
   digest = "1:bb81097a5b62634f3e9fec1014657855610c82d19b9a40c17612e32651e35dca"
@@ -240,12 +240,12 @@
   revision = "4b86a325ce2aa54cb3441ccefe57b0981bf62deb"
 
 [[projects]]
-  digest = "1:7c084e0e780596dd2a7e20d25803909a9a43689c153de953520dfbc0b0e51166"
+  digest = "1:c658e84ad3916da105a761660dcaeb01e63416c8ec7bc62256a9b411a05fcd67"
   name = "github.com/mattn/go-colorable"
   packages = ["."]
   pruneopts = "UT"
-  revision = "8029fb3788e5a4a9c00e415f586a6d033f5d38b3"
-  version = "v0.1.2"
+  revision = "167de6bfdfba052fa6b2d3664c8f5272e23c9072"
+  version = "v0.0.9"
 
 [[projects]]
   digest = "1:9b90c7639a41697f3d4ad12d7d67dfacc9a7a4a6e0bbfae4fc72d0da57c28871"
@@ -360,7 +360,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:2b3ab59cc44bc71aa369afc8ff5cd18e9628cc23e172c6969e091f4f4252fdbd"
+  digest = "1:dc27b2d557157b1f4adc7f53c1b2894b067289ea3bb02175611dc1bfaf6cca0f"
   name = "golang.org/x/crypto"
   packages = [
     "acme",
@@ -369,7 +369,7 @@
     "ssh/terminal",
   ]
   pruneopts = "UT"
-  revision = "f99c8df09eb5bff426315721bfa5f16a99cad32c"
+  revision = "cc06ce4a13d484c0101a9e92913248488a75786d"
 
 [[projects]]
   branch = "master"
@@ -384,7 +384,7 @@
     "idna",
   ]
   pruneopts = "UT"
-  revision = "461777fb6f67e8cb9d70cda16573678d085a74cf"
+  revision = "3b0461eec859c4b73bb64fdc8285971fd33e3938"
 
 [[projects]]
   branch = "master"
@@ -399,14 +399,14 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:7dc7c981bc694f713f6b082ecb7417d8935b74eff5dece50405faa6af62e1ebc"
+  digest = "1:77499c6b3771d12291f289b1f6a5877abc5946d0e85f5930d562d6dcc417137c"
   name = "golang.org/x/sys"
   packages = [
     "unix",
     "windows",
   ]
   pruneopts = "UT"
-  revision = "1e42afee0f762ed3d76e6dd942e4181855fd1849"
+  revision = "e07cf5db2756114766d998ec31e7135ff8c427ed"
 
 [[projects]]
   digest = "1:8d8faad6b12a3a4c819a3f9618cb6ee1fa1cfc33253abeeea8b55336721e3405"
@@ -563,12 +563,12 @@
   version = "v11.0.0"
 
 [[projects]]
-  digest = "1:fa0be820e3b9d58b99264b0ca771ceeb36c7293f8409f70455d4a1e5253a87a0"
+  digest = "1:c283ca5951eb7d723d3300762f96ff94c2ea11eaceb788279e2b7327f92e4f2a"
   name = "k8s.io/klog"
   packages = ["."]
   pruneopts = "UT"
-  revision = "78315d914a8af2453db4864e69230b647b1ff711"
-  version = "v0.3.2"
+  revision = "d98d8acdac006fb39831f1b25640813fef9c314f"
+  version = "v0.3.3"
 
 [[projects]]
   branch = "master"

--- a/pkg/pharos-api-server/application/application.go
+++ b/pkg/pharos-api-server/application/application.go
@@ -5,6 +5,7 @@ import (
 	"github.com/lob/metrics-go"
 	"github.com/lob/pharos/pkg/pharos-api-server/config"
 	"github.com/lob/pharos/pkg/pharos-api-server/database"
+	"github.com/lob/pharos/pkg/shared/token"
 	"github.com/lob/sentry-echo/pkg/sentry"
 	"github.com/pkg/errors"
 )
@@ -12,10 +13,11 @@ import (
 // App contains necessary references that will be persisted throughout the
 // application's lifecycle.
 type App struct {
-	Config  config.Config
-	DB      *pg.DB
-	Metrics metrics.Metrics
-	Sentry  sentry.Sentry
+	Config        config.Config
+	DB            *pg.DB
+	Metrics       metrics.Metrics
+	Sentry        sentry.Sentry
+	TokenVerifier token.Verifier
 }
 
 // New creates a new instance of App with Config, DB connection, Metrics and Sentry.
@@ -43,5 +45,7 @@ func New() (App, error) {
 		return App{}, errors.Wrap(err, "application")
 	}
 
-	return App{cfg, db, m, s}, nil
+	v := token.NewVerifier()
+
+	return App{cfg, db, m, s, v}, nil
 }

--- a/pkg/pharos-api-server/authentication/authentication.go
+++ b/pkg/pharos-api-server/authentication/authentication.go
@@ -1,0 +1,51 @@
+package authentication
+
+import (
+	"strings"
+
+	"github.com/labstack/echo"
+	"github.com/lob/pharos/pkg/shared/token"
+)
+
+const authPrefix = "Bearer "
+
+type authMiddleware struct {
+	tokenValidator token.Verifier
+}
+
+func extractAuthToken(c echo.Context) (string, error) {
+	auth := c.Request().Header.Get(echo.HeaderAuthorization)
+	if auth == "" {
+		return "", echo.NewHTTPError(400, "missing authentication header")
+	}
+
+	if strings.HasPrefix(auth, authPrefix) {
+		return strings.TrimPrefix(auth, authPrefix), nil
+	}
+
+	return "", echo.NewHTTPError(400, "invalid authentication scheme")
+}
+
+// Middleware attaches an authentication middleware that authenticates a request
+// and attaches a token.Idenity struct to the request if properly authenticated.
+func Middleware(verifier token.Verifier) echo.MiddlewareFunc {
+	am := authMiddleware{verifier}
+
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			key, err := extractAuthToken(c)
+			if err != nil {
+				return err
+			}
+
+			identity, err := am.tokenValidator.Verify(key)
+			if err != nil {
+				return echo.NewHTTPError(401)
+			}
+
+			c.Set("auth", identity)
+
+			return next(c)
+		}
+	}
+}

--- a/pkg/pharos-api-server/authentication/authentication.go
+++ b/pkg/pharos-api-server/authentication/authentication.go
@@ -27,7 +27,7 @@ func extractAuthToken(c echo.Context) (string, error) {
 }
 
 // Middleware attaches an authentication middleware that authenticates a request
-// and attaches a token.Idenity struct to the request if properly authenticated.
+// and attaches a token.Identity struct to the request if properly authenticated.
 func Middleware(verifier token.Verifier) echo.MiddlewareFunc {
 	am := authMiddleware{verifier}
 

--- a/pkg/pharos-api-server/authentication/authentication_test.go
+++ b/pkg/pharos-api-server/authentication/authentication_test.go
@@ -1,0 +1,100 @@
+package authentication
+
+import (
+	"errors"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/labstack/echo"
+	"github.com/lob/pharos/pkg/shared/token"
+	"github.com/stretchr/testify/assert"
+)
+
+type mockVerifier struct {
+	Identity *token.Identity
+	Err      error
+}
+
+func (m mockVerifier) Verify(token string) (*token.Identity, error) {
+	m.Identity.AccountID = token
+	return m.Identity, m.Err
+}
+
+func TestMiddleware(t *testing.T) {
+
+	t.Run("successfully authenticates request and sets auth in context", func(tt *testing.T) {
+		successVerifier := mockVerifier{
+			Identity: &token.Identity{
+				ARN: "arn:aws:sts:success-verifier",
+			},
+		}
+		m := Middleware(successVerifier)
+
+		e := echo.New()
+		req := httptest.NewRequest(echo.GET, "/", strings.NewReader(""))
+		req.Header.Set(echo.HeaderAuthorization, "Bearer pharos-v1.pharos-success-test")
+		c := e.NewContext(req, httptest.NewRecorder())
+
+		err := m(func(c echo.Context) error {
+			i := c.Get("auth").(*token.Identity)
+
+			assert.Equal(t, "arn:aws:sts:success-verifier", i.ARN)
+			assert.Equal(t, "pharos-v1.pharos-success-test", i.AccountID)
+
+			return nil
+		})(c)
+
+		assert.NoError(t, err)
+	})
+
+	t.Run("returns an unauthorized error if token validation fails", func(tt *testing.T) {
+		failedVerifier := mockVerifier{
+			Identity: &token.Identity{},
+			Err:      errors.New("token validation failed"),
+		}
+		m := Middleware(failedVerifier)
+
+		e := echo.New()
+		req := httptest.NewRequest(echo.GET, "/", strings.NewReader(""))
+		req.Header.Set(echo.HeaderAuthorization, "Bearer pharos-v1.pharos-success-test")
+		c := e.NewContext(req, httptest.NewRecorder())
+
+		err := m(func(c echo.Context) error {
+			return nil
+		})(c)
+
+		assert.Equal(t, err.(*echo.HTTPError).Code, 401)
+		assert.Contains(t, err.Error(), "Unauthorized")
+	})
+
+	t.Run("returns an error if authentication header is missing", func(tt *testing.T) {
+		m := Middleware(mockVerifier{})
+
+		e := echo.New()
+		req := httptest.NewRequest(echo.GET, "/", strings.NewReader(""))
+		c := e.NewContext(req, httptest.NewRecorder())
+
+		err := m(func(c echo.Context) error {
+			return nil
+		})(c)
+
+		assert.Contains(t, err.Error(), "missing authentication header")
+	})
+
+	t.Run("returns an error if authentication header is incorrect", func(tt *testing.T) {
+		m := Middleware(mockVerifier{})
+
+		e := echo.New()
+		req := httptest.NewRequest(echo.GET, "/", strings.NewReader(""))
+		req.Header.Set(echo.HeaderAuthorization, "Foo bar")
+		c := e.NewContext(req, httptest.NewRecorder())
+
+		err := m(func(c echo.Context) error {
+			return nil
+		})(c)
+
+		assert.Contains(t, err.Error(), "invalid authentication scheme")
+	})
+
+}

--- a/pkg/pharos-api-server/clusters/handlers.go
+++ b/pkg/pharos-api-server/clusters/handlers.go
@@ -14,7 +14,7 @@ type handler struct {
 }
 
 func (h *handler) list(c echo.Context) error {
-	var clusters []*model.Cluster
+	clusters := make([]*model.Cluster, 0)
 
 	err := h.app.DB.
 		Model(&clusters).

--- a/pkg/pharos-api-server/clusters/routes.go
+++ b/pkg/pharos-api-server/clusters/routes.go
@@ -7,12 +7,10 @@ import (
 
 // RegisterRoutes takes in an Echo router and registers routes onto it.
 func RegisterRoutes(e *echo.Echo, app application.App) {
-	g := e.Group("/clusters")
-
 	h := handler{app}
 
-	g.GET("", h.list)
-	g.GET("/:id", h.retrieve)
-	g.DELETE("/:id", h.delete)
-	g.POST("", h.create)
+	e.GET("/clusters", h.list)
+	e.GET("/clusters/:id", h.retrieve)
+	e.DELETE("/clusters/:id", h.delete)
+	e.POST("/clusters", h.create)
 }

--- a/pkg/pharos-api-server/server/server.go
+++ b/pkg/pharos-api-server/server/server.go
@@ -1,6 +1,5 @@
 package server
 
-// New returns a new HTTP server with the registered routes.
 import (
 	"context"
 	"fmt"
@@ -11,6 +10,7 @@ import (
 	logger "github.com/lob/logger-go"
 	metrics "github.com/lob/metrics-go"
 	"github.com/lob/pharos/pkg/pharos-api-server/application"
+	"github.com/lob/pharos/pkg/pharos-api-server/authentication"
 	"github.com/lob/pharos/pkg/pharos-api-server/binder"
 	"github.com/lob/pharos/pkg/pharos-api-server/clusters"
 	"github.com/lob/pharos/pkg/pharos-api-server/health"
@@ -35,6 +35,8 @@ func New(app application.App) *http.Server {
 		Reporter:                  &app.Sentry,
 		EnableCustomErrorMessages: true,
 	})
+
+	e.Use(authentication.Middleware(app.TokenVerifier))
 
 	health.RegisterRoutes(e)
 	clusters.RegisterRoutes(e, app)

--- a/pkg/pharos-api-server/server/server_test.go
+++ b/pkg/pharos-api-server/server/server_test.go
@@ -5,20 +5,30 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/labstack/echo"
 	"github.com/lob/pharos/pkg/pharos-api-server/application"
+	"github.com/lob/pharos/pkg/shared/token"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
+type mockVerifier struct{}
+
+func (m *mockVerifier) Verify(t string) (*token.Identity, error) {
+	return &token.Identity{}, nil
+}
+
 func TestNew(t *testing.T) {
 	app, err := application.New()
 	assert.NoError(t, err)
+	app.TokenVerifier = &mockVerifier{}
 
 	srv := New(app)
 
 	t.Run("serves registered endpoint", func(tt *testing.T) {
 		w := httptest.NewRecorder()
 		req, err := http.NewRequest("GET", "/health", nil)
+		req.Header.Set(echo.HeaderAuthorization, "Bearer pharos-v1.mockToken")
 		require.Nil(t, err, "unexpected error when making new request")
 
 		srv.Handler.ServeHTTP(w, req)
@@ -30,6 +40,7 @@ func TestNew(t *testing.T) {
 	t.Run("handles requests for non-registered endpoints", func(tt *testing.T) {
 		w := httptest.NewRecorder()
 		req, err := http.NewRequest("GET", "/invalid/url/endpoint", nil)
+		req.Header.Set(echo.HeaderAuthorization, "Bearer pharos-v1.mockToken")
 		require.Nil(t, err, "unexpected error when making new request")
 
 		srv.Handler.ServeHTTP(w, req)


### PR DESCRIPTION
## What & Why
- [x] Add an `authentication` middleware
- [x] Refactor clusters register routers endpoints to not use groups
    - echo groups add additional routes that we don't necessarily want in our application. I'm not sure why echo does this.
- [x] Refactor list handler to initialize an empty slice rather an a nil slice
    - This prevents `null` responses in place of an empty list (`[]`) when there is nothing to be returned.
