### PR TITLE
feat(cli): add pharos clusters update command

### DIFF
--- a/pkg/pharos/api/pharos.go
+++ b/pkg/pharos/api/pharos.go
@@ -44,3 +44,20 @@ func (c *Client) GetCluster(clusterID string) (model.Cluster, error) {
 
 	return cluster, nil
 }
+
+// UpdateCluster sends a POST request to the clusters/id endpoint of the Pharos API
+// and returns a Cluster containing the updated cluster.
+func (c *Client) UpdateCluster(clusterID string, active bool) (model.Cluster, error) {
+	var cluster model.Cluster
+	type temp struct {
+		Active bool `json:"active"`
+	}
+	update := &temp{Active: active}
+
+	err := c.send(http.MethodPost, fmt.Sprintf("clusters/%s", clusterID), nil, &update, &cluster)
+	if err != nil {
+		return cluster, errors.Wrapf(err, "failed to update cluster %s status to %t", clusterID, active)
+	}
+
+	return cluster, nil
+}

--- a/pkg/pharos/api/pharos.go
+++ b/pkg/pharos/api/pharos.go
@@ -49,12 +49,11 @@ func (c *Client) GetCluster(clusterID string) (model.Cluster, error) {
 // and returns a Cluster containing the updated cluster.
 func (c *Client) UpdateCluster(clusterID string, active bool) (model.Cluster, error) {
 	var cluster model.Cluster
-	type temp struct {
+	update := &struct {
 		Active bool `json:"active"`
-	}
-	update := &temp{Active: active}
+	}{Active: active}
 
-	err := c.send(http.MethodPost, fmt.Sprintf("clusters/%s", clusterID), nil, &update, &cluster)
+	err := c.send(http.MethodPost, fmt.Sprintf("clusters/%s", clusterID), nil, update, &cluster)
 	if err != nil {
 		return cluster, errors.Wrapf(err, "failed to update cluster %s status to %t", clusterID, active)
 	}

--- a/pkg/pharos/api/pharos_test.go
+++ b/pkg/pharos/api/pharos_test.go
@@ -114,3 +114,35 @@ func TestGetCluster(t *testing.T) {
 		assert.Equal(tt, "", cluster.ID)
 	})
 }
+
+func TestUpdateCluster(t *testing.T) {
+	testResponse := []byte(`{
+		"id":                     "production-pikachu",
+		"environment":            "production",
+		"server_url":             "https://prod.elb.us-west-2.amazonaws.com:6443",
+		"cluster_authority_data": "asdasd",
+		"deleted":                false,
+		"active":                 true
+	}`)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		_, err := rw.Write(testResponse)
+		require.NoError(t, err)
+	}))
+	defer srv.Close()
+
+	t.Run("updates cluster by ID successfully", func(tt *testing.T) {
+		c := NewClient(&config.Config{BaseURL: srv.URL})
+		cluster, err := c.UpdateCluster("production-pikachu", true)
+		assert.NoError(tt, err)
+		assert.Equal(tt, "production-pikachu", cluster.ID)
+		assert.Equal(tt, true, cluster.Active)
+	})
+
+	t.Run("fails to create cluster using a bad client", func(tt *testing.T) {
+		c := NewClient(&config.Config{BaseURL: ""})
+		cluster, err := c.UpdateCluster("production-pikachu", true)
+		assert.Error(tt, err)
+		assert.Equal(tt, "", cluster.ID)
+	})
+}

--- a/pkg/pharos/cmd/list.go
+++ b/pkg/pharos/cmd/list.go
@@ -17,7 +17,7 @@ var inactive bool
 // currently registered with pharos-api.
 var ListCmd = &cobra.Command{
 	Use:   "list",
-	Short: "Retrieves a list of all clusters.",
+	Short: "Retrieves a list of all clusters",
 	Long:  "Retrieves a list of all clusters currently registered with Pharos.",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		client, err := api.ClientFromConfig(pharosConfig)

--- a/pkg/pharos/cmd/root.go
+++ b/pkg/pharos/cmd/root.go
@@ -39,10 +39,11 @@ func init() {
 	// Add child commands.
 	rootCmd.AddCommand(clustersCmd)
 	clustersCmd.AddCommand(CurrentCmd)
-	clustersCmd.AddCommand(SwitchCmd)
+	clustersCmd.AddCommand(DeleteCmd)
 	clustersCmd.AddCommand(GetCmd)
 	clustersCmd.AddCommand(ListCmd)
-	clustersCmd.AddCommand(DeleteCmd)
+	clustersCmd.AddCommand(SwitchCmd)
+	clustersCmd.AddCommand(UpdateCmd)
 }
 
 // argID prevents commands from being run unless exactly one argument (a cluster name or id)

--- a/pkg/pharos/cmd/update.go
+++ b/pkg/pharos/cmd/update.go
@@ -1,0 +1,42 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/fatih/color"
+	"github.com/lob/pharos/pkg/pharos/api"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+)
+
+// Declare some variables to be used as flags.
+var active bool
+
+// UpdateCmd implements a CLI command that allows users to update the status of
+// a cluster in Pharos.
+var UpdateCmd = &cobra.Command{
+	Use:   "update <cluster_id>",
+	Short: "Updates the status of a cluster",
+	Long:  "Updates the status of the specified cluster in Pharos.",
+	Args:  func(cmd *cobra.Command, args []string) error { return argID(args) },
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := api.ClientFromConfig(pharosConfig)
+		if err != nil {
+			return errors.Wrap(err, "unable to create client from pharos config file")
+		}
+		return runUpdate(args[0], active, client)
+	},
+}
+
+func runUpdate(id string, active bool, client *api.Client) error {
+	cluster, err := client.UpdateCluster(id, active)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("%s CLUSTER %s UPDATED TO STATUS %t\n", color.GreenString("SUCCESS:"), cluster.ID, cluster.Active)
+	return nil
+}
+
+func init() {
+	UpdateCmd.Flags().BoolVarP(&active, "active", "a", true, "specify whether to set the cluster status to active")
+}

--- a/pkg/pharos/cmd/update.go
+++ b/pkg/pharos/cmd/update.go
@@ -33,7 +33,7 @@ func runUpdate(id string, active bool, client *api.Client) error {
 	if err != nil {
 		return err
 	}
-	fmt.Printf("%s CLUSTER %s UPDATED TO STATUS %t\n", color.GreenString("SUCCESS:"), cluster.ID, cluster.Active)
+	fmt.Printf("%s CLUSTER %s ACTIVE STATUS UPDATED TO %t\n", color.GreenString("SUCCESS:"), cluster.ID, cluster.Active)
 	return nil
 }
 

--- a/pkg/pharos/cmd/update_test.go
+++ b/pkg/pharos/cmd/update_test.go
@@ -1,0 +1,54 @@
+package cmd
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/lob/pharos/pkg/pharos/api"
+	configpkg "github.com/lob/pharos/pkg/pharos/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRunUpdate(t *testing.T) {
+	t.Run("successfully updates a cluster", func(tt *testing.T) {
+		// Set up dummy server for testing.
+		updateClusters := []byte(`{
+			"id":                     "sandbox-333333",
+			"environment":            "sandbox",
+			"cluster_authority_data": "LS0tLS1CRUdJTiBDR...",
+			"server_url":             "https://test.elb.us-west-2.amazonaws.com:6443",
+			"object":                 "cluster",
+			"deleted":                true,
+			"active":                 false
+		}`)
+
+		srv := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+			_, err := rw.Write(updateClusters)
+			require.NoError(tt, err)
+		}))
+		defer srv.Close()
+
+		// Set BaseURL in config to be the url of the dummy server.
+		client := api.NewClient(&configpkg.Config{BaseURL: srv.URL})
+
+		err := runUpdate("sandbox-333333", false, client)
+		assert.NoError(tt, err)
+	})
+
+	t.Run("errors when the api server fails to respond", func(tt *testing.T) {
+		// Set up dummy server for testing.
+		srv := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+			_, err := rw.Write([]byte(``))
+			require.NoError(tt, err)
+		}))
+		defer srv.Close()
+
+		// Set BaseURL in config to be the url of the dummy server.
+		client := api.NewClient(&configpkg.Config{BaseURL: srv.URL})
+
+		err := runUpdate("sandbox-333333", false, client)
+		assert.Error(tt, err)
+	})
+}


### PR DESCRIPTION
### what & why
- adds `pharos clusters update` command to the CLI
- this command updates a cluster's status - the default sets active to true (updating a cluster to be an active cluster)

### notes
- ~will there ever be a time when we want two active clusters at once? should i add more functionality to also set the currently active cluster as `inactive` whenever we "promote" a new cluster to `active`?~ edit: talked to donald, the api server already takes care of this by setting all other clusters of the same environment to inactive when we set a new cluster to active.
- unable to test this locally because the update endpoint has not yet been merged in - will test locally before merging in
- also, won't be able to test locally until the cli auth PR has been merged in