### PR TITLE
feat(cli): add authentication to cli to handle running on EC2 instances in our clusters

### DIFF
--- a/pkg/pharos/config/config.go
+++ b/pkg/pharos/config/config.go
@@ -12,9 +12,10 @@ import (
 // Config contains the configuration for this CLI.
 // It is used to create a Client for the Pharos API server.
 type Config struct {
-	BaseURL    string `json:"base_url"`
-	AWSProfile string `json:"aws_profile"`
-	filePath   string
+	BaseURL       string `json:"base_url"`
+	AWSProfile    string `json:"aws_profile"`
+	AssumeRoleARN string `json:"assume_role_arn"`
+	filePath      string
 }
 
 const (


### PR DESCRIPTION
### what & why
- add auth to cli to handle running on EC2 instances in our clusters

### next steps
- add roles for "pharosEC2Instance" to each account
- allow the kubernetes cluster to assume role for that role
- pass the arn of the `pharosEC2Instance` role to the terraform module to create a kubernetes_cluster
- create pharos config file upon startup of each kubernetes cluster in ~/.kube/pharos/config with `assume_role_arn` set to the ARN of the `pharosEC2Instance` role
- download the pharos cli in the terraform module and create a cluster in the pharos api server inside the cluster
- also, i'm not sure how to test this D: