### PR TITLE
feat(authorization): add authorization to endpoints

### DIFF
--- a/pkg/pharos-api-server/authentication/authentication_test.go
+++ b/pkg/pharos-api-server/authentication/authentication_test.go
@@ -22,7 +22,6 @@ func (m mockVerifier) Verify(token string) (*token.Identity, error) {
 }
 
 func TestMiddleware(t *testing.T) {
-
 	t.Run("successfully authenticates request and sets auth in context", func(tt *testing.T) {
 		successVerifier := mockVerifier{
 			Identity: &token.Identity{

--- a/pkg/pharos-api-server/authorization/authorization.go
+++ b/pkg/pharos-api-server/authorization/authorization.go
@@ -8,7 +8,8 @@ import (
 )
 
 // Middleware attaches an authorization middleware that authenticates a request
-// against the authenticated used from the authentication middleware.  attaches a token.Identity struct to the request if properly authenticated.
+// against the authenticated user from the authentication middleware. Attaches a
+// token.Identity struct to the request if properly authenticated.
 func Middleware(allowedARNs []string) echo.MiddlewareFunc {
 	return func(next echo.HandlerFunc) echo.HandlerFunc {
 		return func(c echo.Context) error {

--- a/pkg/pharos-api-server/authorization/authorization.go
+++ b/pkg/pharos-api-server/authorization/authorization.go
@@ -1,0 +1,31 @@
+package authorization
+
+import (
+	"net/http"
+
+	"github.com/labstack/echo"
+	"github.com/lob/pharos/pkg/util/token"
+)
+
+// Middleware attaches an authorization middleware that authenticates a request
+// against the authenticated used from the authentication middleware.  attaches a token.Identity struct to the request if properly authenticated.
+func Middleware(allowedARNs []string) echo.MiddlewareFunc {
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			var authARN string
+			if identity, ok := c.Get("auth").(*token.Identity); ok {
+				authARN = identity.CanonicalARN
+			} else {
+				return echo.NewHTTPError(http.StatusUnauthorized)
+			}
+
+			for _, allowedArn := range allowedARNs {
+				if allowedArn == authARN {
+					return next(c)
+				}
+			}
+
+			return echo.NewHTTPError(http.StatusUnauthorized)
+		}
+	}
+}

--- a/pkg/pharos-api-server/authorization/authorization_test.go
+++ b/pkg/pharos-api-server/authorization/authorization_test.go
@@ -1,0 +1,45 @@
+package authorization
+
+import (
+	"testing"
+
+	"github.com/labstack/echo"
+	"github.com/lob/pharos/pkg/util/token"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMiddleware(t *testing.T) {
+	e := echo.New()
+
+	t.Run("succesfully authorizes a valid request", func(tt *testing.T) {
+		c := e.NewContext(nil, nil)
+		c.Set("auth", &token.Identity{CanonicalARN: "admin"})
+
+		m := Middleware([]string{"admin"})
+
+		err := m(func(c echo.Context) error { return nil })(c)
+		assert.NoError(t, err)
+	})
+
+	t.Run("rejects an invalid authorization request", func(tt *testing.T) {
+		c := e.NewContext(nil, nil)
+		c.Set("auth", &token.Identity{CanonicalARN: "read"})
+
+		m := Middleware([]string{"admin"})
+
+		err := m(func(c echo.Context) error { return nil })(c)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "Unauthorized")
+	})
+
+	t.Run("rejects a request if auth is not set", func(tt *testing.T) {
+		c := e.NewContext(nil, nil)
+
+		m := Middleware([]string{"admin"})
+
+		err := m(func(c echo.Context) error { return nil })(c)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "Unauthorized")
+	})
+
+}

--- a/pkg/pharos-api-server/clusters/routes.go
+++ b/pkg/pharos-api-server/clusters/routes.go
@@ -16,6 +16,6 @@ func RegisterRoutes(e *echo.Echo, app application.App) {
 	e.GET("/clusters", h.list, authentication.Middleware(app.TokenVerifier), authorization.Middleware(config.Permissions.Read))
 	e.GET("/clusters/:id", h.retrieve, authentication.Middleware(app.TokenVerifier), authorization.Middleware(config.Permissions.Read))
 	e.DELETE("/clusters/:id", h.delete, authentication.Middleware(app.TokenVerifier), authorization.Middleware(config.Permissions.Admin))
-	e.POST("/clusters", h.create, authentication.Middleware(app.TokenVerifier), authorization.Middleware(config.Permissions.Robot))
+	e.POST("/clusters", h.create, authentication.Middleware(app.TokenVerifier), authorization.Middleware(config.Permissions.Write))
 	e.POST("/clusters/:id", h.update, authentication.Middleware(app.TokenVerifier), authorization.Middleware(config.Permissions.Admin))
 }

--- a/pkg/pharos-api-server/clusters/routes.go
+++ b/pkg/pharos-api-server/clusters/routes.go
@@ -3,15 +3,19 @@ package clusters
 import (
 	"github.com/labstack/echo"
 	"github.com/lob/pharos/pkg/pharos-api-server/application"
+	"github.com/lob/pharos/pkg/pharos-api-server/authentication"
+	"github.com/lob/pharos/pkg/pharos-api-server/authorization"
 )
 
 // RegisterRoutes takes in an Echo router and registers routes onto it.
 func RegisterRoutes(e *echo.Echo, app application.App) {
 	h := handler{app}
 
-	e.GET("/clusters", h.list)
-	e.GET("/clusters/:id", h.retrieve)
-	e.DELETE("/clusters/:id", h.delete)
-	e.POST("/clusters", h.create)
-	e.POST("/clusters/:id", h.update)
+	config := app.Config
+
+	e.GET("/clusters", h.list, authentication.Middleware(app.TokenVerifier), authorization.Middleware(config.Permissions.Read))
+	e.GET("/clusters/:id", h.retrieve, authentication.Middleware(app.TokenVerifier), authorization.Middleware(config.Permissions.Read))
+	e.DELETE("/clusters/:id", h.delete, authentication.Middleware(app.TokenVerifier), authorization.Middleware(config.Permissions.Admin))
+	e.POST("/clusters", h.create, authentication.Middleware(app.TokenVerifier), authorization.Middleware(config.Permissions.Robot))
+	e.POST("/clusters/:id", h.update, authentication.Middleware(app.TokenVerifier), authorization.Middleware(config.Permissions.Admin))
 }

--- a/pkg/pharos-api-server/clusters/routes_test.go
+++ b/pkg/pharos-api-server/clusters/routes_test.go
@@ -5,12 +5,23 @@ import (
 
 	"github.com/labstack/echo"
 	"github.com/lob/pharos/pkg/pharos-api-server/application"
+	"github.com/lob/pharos/pkg/pharos-api-server/config"
+	"github.com/lob/pharos/pkg/util/token"
 	"github.com/stretchr/testify/assert"
 )
 
+type mockVerifier struct{}
+
+func (m *mockVerifier) Verify(t string) (*token.Identity, error) {
+	return &token.Identity{}, nil
+}
+
 func TestRegisterRoutes(t *testing.T) {
 	e := echo.New()
-	app := application.App{}
+	app := application.App{
+		Config:        config.New(),
+		TokenVerifier: &mockVerifier{},
+	}
 
 	RegisterRoutes(e, app)
 

--- a/pkg/pharos-api-server/config/config.go
+++ b/pkg/pharos-api-server/config/config.go
@@ -28,7 +28,7 @@ type Config struct {
 type Permissions struct {
 	Admin []string
 	Read  []string
-	Robot []string
+	Write []string
 }
 
 const env = "ENVIRONMENT"
@@ -77,12 +77,12 @@ func New() Config {
 		cfg.Permissions.Read = append(strings.Split(readRoles, ","), cfg.Permissions.Admin...)
 	}
 
-	// Load machine IAM roles
-	if robotRoles := os.Getenv("ROBOT_ACCESS_ROLES"); robotRoles != "" {
+	// Load write IAM roles
+	if writeRoles := os.Getenv("WRITE_ACCESS_ROLES"); writeRoles != "" {
 		// As admins are allowed to perform any action we append their roles to the
-		// Robot list of ARNs to prevent having to add both the Robot and Admin roles
+		// Write list of ARNs to prevent having to add both the Write and Admin roles
 		// everywhere. There is no issue with a role appearing twice in this list.
-		cfg.Permissions.Robot = append(strings.Split(robotRoles, ","), cfg.Permissions.Admin...)
+		cfg.Permissions.Write = append(strings.Split(writeRoles, ","), cfg.Permissions.Admin...)
 	}
 
 	return cfg

--- a/pkg/pharos-api-server/config/config_test.go
+++ b/pkg/pharos-api-server/config/config_test.go
@@ -11,27 +11,27 @@ import (
 func TestNew(t *testing.T) {
 	originalAdminAccessRoles := os.Getenv("ADMIN_ACCESS_ROLES")
 	originalReadAccessRoles := os.Getenv("READ_ACCESS_ROLES")
-	originalRobotAccessRoles := os.Getenv("ROBOT_ACCESS_ROLES")
+	originalWriteAccessRoles := os.Getenv("WRITE_ACCESS_ROLES")
 	defer func() {
 		err := os.Setenv("ADMIN_ACCESS_ROLES", originalAdminAccessRoles)
 		require.Nil(t, err, "unexpected error restoring original ADMIN_ACCESS_ROLES")
 		err = os.Setenv("READ_ACCESS_ROLES", originalReadAccessRoles)
 		require.Nil(t, err, "unexpected error restoring original READ_ACCESS_ROLES")
-		err = os.Setenv("ROBOT_ACCESS_ROLES", originalRobotAccessRoles)
-		require.Nil(t, err, "unexpected error restoring original ROBOT_ACCESS_ROLES")
+		err = os.Setenv("WRITE_ACCESS_ROLES", originalWriteAccessRoles)
+		require.Nil(t, err, "unexpected error restoring original WRITE_ACCESS_ROLES")
 	}()
 
 	err := os.Setenv("ADMIN_ACCESS_ROLES", "admin")
 	require.Nil(t, err, "unexpected error setting test env value for ADMIN_ACCESS_ROLES")
 	err = os.Setenv("READ_ACCESS_ROLES", "read1,read2")
 	require.Nil(t, err, "unexpected error setting test env value for READ_ACCESS_ROLES")
-	err = os.Setenv("ROBOT_ACCESS_ROLES", "robot")
-	require.Nil(t, err, "unexpected error setting test env value for ROBOT_ACCESS_ROLES")
+	err = os.Setenv("WRITE_ACCESS_ROLES", "write")
+	require.Nil(t, err, "unexpected error setting test env value for WRITE_ACCESS_ROLES")
 
 	cfg := New()
 	assert.Equal(t, 7654, cfg.Port)
 	assert.NotNil(t, cfg, "returned config shouldn't be nil")
 	assert.Equal(t, []string{"admin"}, cfg.Permissions.Admin)
 	assert.Equal(t, []string{"read1", "read2", "admin"}, cfg.Permissions.Read)
-	assert.Equal(t, []string{"robot", "admin"}, cfg.Permissions.Robot)
+	assert.Equal(t, []string{"write", "admin"}, cfg.Permissions.Write)
 }

--- a/pkg/pharos-api-server/config/config_test.go
+++ b/pkg/pharos-api-server/config/config_test.go
@@ -1,13 +1,37 @@
 package config
 
 import (
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNew(t *testing.T) {
+	originalAdminAccessRoles := os.Getenv("ADMIN_ACCESS_ROLES")
+	originalReadAccessRoles := os.Getenv("READ_ACCESS_ROLES")
+	originalRobotAccessRoles := os.Getenv("ROBOT_ACCESS_ROLES")
+	defer func() {
+		err := os.Setenv("ADMIN_ACCESS_ROLES", originalAdminAccessRoles)
+		require.Nil(t, err, "unexpected error restoring original ADMIN_ACCESS_ROLES")
+		err = os.Setenv("READ_ACCESS_ROLES", originalReadAccessRoles)
+		require.Nil(t, err, "unexpected error restoring original READ_ACCESS_ROLES")
+		err = os.Setenv("ROBOT_ACCESS_ROLES", originalRobotAccessRoles)
+		require.Nil(t, err, "unexpected error restoring original ROBOT_ACCESS_ROLES")
+	}()
+
+	err := os.Setenv("ADMIN_ACCESS_ROLES", "admin")
+	require.Nil(t, err, "unexpected error setting test env value for ADMIN_ACCESS_ROLES")
+	err = os.Setenv("READ_ACCESS_ROLES", "read1,read2")
+	require.Nil(t, err, "unexpected error setting test env value for READ_ACCESS_ROLES")
+	err = os.Setenv("ROBOT_ACCESS_ROLES", "robot")
+	require.Nil(t, err, "unexpected error setting test env value for ROBOT_ACCESS_ROLES")
+
 	cfg := New()
 	assert.Equal(t, 7654, cfg.Port)
 	assert.NotNil(t, cfg, "returned config shouldn't be nil")
+	assert.Equal(t, []string{"admin"}, cfg.Permissions.Admin)
+	assert.Equal(t, []string{"read1", "read2", "admin"}, cfg.Permissions.Read)
+	assert.Equal(t, []string{"robot", "admin"}, cfg.Permissions.Robot)
 }

--- a/pkg/pharos-api-server/server/server.go
+++ b/pkg/pharos-api-server/server/server.go
@@ -10,7 +10,6 @@ import (
 	logger "github.com/lob/logger-go"
 	metrics "github.com/lob/metrics-go"
 	"github.com/lob/pharos/pkg/pharos-api-server/application"
-	"github.com/lob/pharos/pkg/pharos-api-server/authentication"
 	"github.com/lob/pharos/pkg/pharos-api-server/binder"
 	"github.com/lob/pharos/pkg/pharos-api-server/clusters"
 	"github.com/lob/pharos/pkg/pharos-api-server/health"
@@ -35,8 +34,6 @@ func New(app application.App) *http.Server {
 		Reporter:                  &app.Sentry,
 		EnableCustomErrorMessages: true,
 	})
-
-	e.Use(authentication.Middleware(app.TokenVerifier))
 
 	health.RegisterRoutes(e)
 	clusters.RegisterRoutes(e, app)

--- a/pkg/pharos-api-server/server/server_test.go
+++ b/pkg/pharos-api-server/server/server_test.go
@@ -5,7 +5,6 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/labstack/echo"
 	"github.com/lob/pharos/pkg/pharos-api-server/application"
 	"github.com/lob/pharos/pkg/util/token"
 	"github.com/stretchr/testify/assert"
@@ -21,14 +20,12 @@ func (m *mockVerifier) Verify(t string) (*token.Identity, error) {
 func TestNew(t *testing.T) {
 	app, err := application.New()
 	assert.NoError(t, err)
-	app.TokenVerifier = &mockVerifier{}
 
 	srv := New(app)
 
 	t.Run("serves registered endpoint", func(tt *testing.T) {
 		w := httptest.NewRecorder()
 		req, err := http.NewRequest("GET", "/health", nil)
-		req.Header.Set(echo.HeaderAuthorization, "Bearer pharos-v1.mockToken")
 		require.Nil(t, err, "unexpected error when making new request")
 
 		srv.Handler.ServeHTTP(w, req)
@@ -40,7 +37,6 @@ func TestNew(t *testing.T) {
 	t.Run("handles requests for non-registered endpoints", func(tt *testing.T) {
 		w := httptest.NewRecorder()
 		req, err := http.NewRequest("GET", "/invalid/url/endpoint", nil)
-		req.Header.Set(echo.HeaderAuthorization, "Bearer pharos-v1.mockToken")
 		require.Nil(t, err, "unexpected error when making new request")
 
 		srv.Handler.ServeHTTP(w, req)


### PR DESCRIPTION
## What
- [x] Add an authorization middleware
- [x] Move the authentication middleware from the server to each individual endpoint
  - This allows the `echo.NotFoundHandler` to run without the authentication middleware which lets us return a 404 Not Found error instead of a 401 Unauthorized for unknown routes.