### PR TITLE
feat(cli): add pharos setup command

### DIFF
--- a/pkg/pharos/cmd/current_test.go
+++ b/pkg/pharos/cmd/current_test.go
@@ -4,18 +4,17 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestRunCurrent(t *testing.T) {
 	t.Run("successfully retrieves current cluster", func(tt *testing.T) {
 		err := runCurrent(config)
-		require.NoError(tt, err)
+		assert.NoError(tt, err)
 	})
 
 	t.Run("errors successfully when retrieving from malformed config", func(tt *testing.T) {
 		err := runCurrent(malformedConfig)
-		require.Error(tt, err)
+		assert.Error(tt, err)
 		assert.Contains(tt, err.Error(), "unable to retrieve cluster")
 	})
 }

--- a/pkg/pharos/cmd/root.go
+++ b/pkg/pharos/cmd/root.go
@@ -21,12 +21,16 @@ var (
 var rootCmd = &cobra.Command{
 	Use:     "pharos",
 	Short:   "A tool for managing kubeconfig files.",
-	Long:    `Pharos is a tool for cluster discovery and distribution of kubeconfig files.`,
+	Long:    "Pharos is a tool for cluster discovery and distribution of kubeconfig files.",
 	Version: "1.0",
 }
 
 // clustersCmd is the pharos clusters command.
-var clustersCmd = &cobra.Command{Use: "clusters"}
+var clustersCmd = &cobra.Command{
+	Use:   "clusters",
+	Short: "Commands for cluster management (run \"pharos clusters -h\" for a full list of cluster commands)",
+	Long:  "Commands for managing cluster kubeconfig files.",
+}
 
 // Execute adds all child commands to the root command and sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
@@ -43,6 +47,7 @@ func init() {
 
 	// Add child commands.
 	rootCmd.AddCommand(clustersCmd)
+	rootCmd.AddCommand(setupCmd)
 	clustersCmd.AddCommand(CreateCmd)
 	clustersCmd.AddCommand(CurrentCmd)
 	clustersCmd.AddCommand(DeleteCmd)

--- a/pkg/pharos/cmd/root.go
+++ b/pkg/pharos/cmd/root.go
@@ -28,7 +28,7 @@ var rootCmd = &cobra.Command{
 // clustersCmd is the pharos clusters command.
 var clustersCmd = &cobra.Command{
 	Use:   "clusters",
-	Short: "Commands for cluster management (run \"pharos clusters -h\" for a full list of cluster commands)",
+	Short: `Commands for cluster management (run "pharos clusters -h" for a full list of cluster commands)`,
 	Long:  "Commands for managing cluster kubeconfig files.",
 }
 

--- a/pkg/pharos/cmd/root_test.go
+++ b/pkg/pharos/cmd/root_test.go
@@ -8,6 +8,7 @@ import (
 
 // Declare some constants to be used in testing functions used in various commands.
 const (
+	cliConfig       = "../testdata/pharosConfig"
 	config          = "../testdata/config"
 	malformedConfig = "../testdata/malformed"
 	emptyConfig     = "../testdata/empty"

--- a/pkg/pharos/cmd/setup.go
+++ b/pkg/pharos/cmd/setup.go
@@ -1,0 +1,49 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/fatih/color"
+	configpkg "github.com/lob/pharos/pkg/pharos/config"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+)
+
+// Declare variables to be used as flags.
+var awsProfile string
+var awsRoleARN string
+var pharosURL string
+
+// setupCmd is the pharos setup command.
+var setupCmd = &cobra.Command{
+	Use:   "setup",
+	Short: "Setup Pharos config",
+	Long:  "Setup Pharos configuration file. Overwrites previously saved configuration.",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return runSetup(pharosConfig, pharosURL, awsProfile, awsRoleARN)
+	},
+}
+
+func runSetup(pharosConfig string, url string, profile string, arn string) error {
+	c, err := configpkg.New(pharosConfig)
+	if err != nil {
+		return errors.Wrap(err, "unable to create reference to config file")
+	}
+
+	c.BaseURL = url
+	c.AWSProfile = profile
+	c.AssumeRoleARN = arn
+
+	err = c.Save()
+	if err != nil {
+		return errors.Wrap(err, "unable to save config file")
+	}
+	fmt.Printf("%s SAVED CONFIG TO %s\n", color.GreenString("SUCCESS:"), pharosConfig)
+	return nil
+}
+
+func init() {
+	setupCmd.Flags().StringVarP(&awsProfile, "aws-profile", "p", "", "specify aws profile to use")
+	setupCmd.Flags().StringVarP(&awsRoleARN, "aws-role-arn", "r", "", "specify aws role ARN to use")
+	setupCmd.Flags().StringVarP(&pharosURL, "pharos-url", "u", "", "specify URL of the pharos server")
+}

--- a/pkg/pharos/cmd/setup.go
+++ b/pkg/pharos/cmd/setup.go
@@ -32,6 +32,13 @@ func runSetup(pharosConfig, url, profile, arn string) error {
 		return errors.Wrap(err, "unable to create reference to config file")
 	}
 
+	// Load old config file to prevent overwrites. If this errors, config file
+	// has not yet been configured.
+	err = c.Load()
+	if err != nil {
+		fmt.Println("CREATING PHAROS CONFIG FILE...")
+	}
+
 	if url != "" {
 		c.BaseURL = url
 	}

--- a/pkg/pharos/cmd/setup.go
+++ b/pkg/pharos/cmd/setup.go
@@ -30,7 +30,7 @@ func runSetup(pharosConfig string, url string, profile string, arn string) error
 		return errors.Wrap(err, "unable to create reference to config file")
 	}
 
-	if c.BaseUrl != "" {
+	if c.BaseURL != "" {
 		c.BaseURL = url
 	}
 	if c.AWSProfile != "" {

--- a/pkg/pharos/cmd/setup.go
+++ b/pkg/pharos/cmd/setup.go
@@ -10,9 +10,11 @@ import (
 )
 
 // Declare variables to be used as flags.
-var awsProfile string
-var awsRoleARN string
-var pharosURL string
+var (
+	awsProfile string
+	awsRoleARN string
+	pharosURL  string
+)
 
 // setupCmd is the pharos setup command.
 var setupCmd = &cobra.Command{
@@ -24,7 +26,7 @@ var setupCmd = &cobra.Command{
 	},
 }
 
-func runSetup(pharosConfig string, url string, profile string, arn string) error {
+func runSetup(pharosConfig, url, profile, arn string) error {
 	c, err := configpkg.New(pharosConfig)
 	if err != nil {
 		return errors.Wrap(err, "unable to create reference to config file")
@@ -51,5 +53,5 @@ func runSetup(pharosConfig string, url string, profile string, arn string) error
 func init() {
 	setupCmd.Flags().StringVarP(&awsProfile, "aws-profile", "p", "", "specify aws profile to use")
 	setupCmd.Flags().StringVarP(&awsRoleARN, "aws-role-arn", "r", "", "specify aws role ARN to use")
-	setupCmd.Flags().StringVarP(&pharosURL, "pharos-url", "u", "", "specify URL of the pharos server")
+	setupCmd.Flags().StringVarP(&pharosURL, "pharos-url", "u", "", "specify URL of the Pharos server")
 }

--- a/pkg/pharos/cmd/setup.go
+++ b/pkg/pharos/cmd/setup.go
@@ -30,9 +30,15 @@ func runSetup(pharosConfig string, url string, profile string, arn string) error
 		return errors.Wrap(err, "unable to create reference to config file")
 	}
 
-	c.BaseURL = url
-	c.AWSProfile = profile
-	c.AssumeRoleARN = arn
+	if c.BaseUrl != "" {
+		c.BaseURL = url
+	}
+	if c.AWSProfile != "" {
+		c.AWSProfile = profile
+	}
+	if c.AssumeRoleARN != "" {
+		c.AssumeRoleARN = arn
+	}
 
 	err = c.Save()
 	if err != nil {

--- a/pkg/pharos/cmd/setup.go
+++ b/pkg/pharos/cmd/setup.go
@@ -30,13 +30,13 @@ func runSetup(pharosConfig string, url string, profile string, arn string) error
 		return errors.Wrap(err, "unable to create reference to config file")
 	}
 
-	if c.BaseURL != "" {
+	if url != "" {
 		c.BaseURL = url
 	}
-	if c.AWSProfile != "" {
+	if profile != "" {
 		c.AWSProfile = profile
 	}
-	if c.AssumeRoleARN != "" {
+	if arn != "" {
 		c.AssumeRoleARN = arn
 	}
 

--- a/pkg/pharos/cmd/setup_test.go
+++ b/pkg/pharos/cmd/setup_test.go
@@ -28,5 +28,18 @@ func TestRunSetup(t *testing.T) {
 		assert.Equal(tt, "egg", c.BaseURL)
 		assert.Equal(tt, "hello", c.AWSProfile)
 		assert.Equal(tt, "", c.AssumeRoleARN)
+
+		// Check that setup doesn't overwrite file.
+		err = runSetup(configFile, "", "blah", "test")
+		assert.NoError(tt, err)
+
+		c, err = configpkg.New(configFile)
+		assert.NoError(tt, err)
+		err = c.Load()
+		assert.NoError(tt, err)
+
+		assert.Equal(tt, "egg", c.BaseURL)
+		assert.Equal(tt, "blah", c.AWSProfile)
+		assert.Equal(tt, "test", c.AssumeRoleARN)
 	})
 }

--- a/pkg/pharos/cmd/setup_test.go
+++ b/pkg/pharos/cmd/setup_test.go
@@ -1,0 +1,32 @@
+package cmd
+
+import (
+	"os"
+	"testing"
+
+	"github.com/lob/pharos/internal/test"
+	configpkg "github.com/lob/pharos/pkg/pharos/config"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRunSetup(t *testing.T) {
+	t.Run("successfully initializes the pharos config file", func(tt *testing.T) {
+		// Create temporary test config file and defer cleanup.
+		configFile := test.CopyTestFile(tt, "../testdata", "setup", cliConfig)
+		defer os.Remove(configFile)
+
+		// Setup file.
+		err := runSetup(configFile, "egg", "hello", "")
+		assert.NoError(tt, err)
+
+		// Check that file setup was successful.
+		c, err := configpkg.New(configFile)
+		assert.NoError(tt, err)
+		err = c.Load()
+		assert.NoError(tt, err)
+
+		assert.Equal(tt, "egg", c.BaseURL)
+		assert.Equal(tt, "hello", c.AWSProfile)
+		assert.Equal(tt, "", c.AssumeRoleARN)
+	})
+}

--- a/pkg/pharos/cmd/switch_test.go
+++ b/pkg/pharos/cmd/switch_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/lob/pharos/internal/test"
 	"github.com/lob/pharos/pkg/pharos/cli"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestRunSwitch(t *testing.T) {
@@ -18,17 +17,17 @@ func TestRunSwitch(t *testing.T) {
 
 		// Switch to a different cluster.
 		err := runSwitch(configFile, "sandbox-111111")
-		require.NoError(tt, err)
+		assert.NoError(tt, err)
 
 		// Check that switch was successful.
 		clusterName, err := cli.CurrentCluster(configFile)
-		require.NoError(tt, err)
-		require.Equal(tt, "sandbox-111111", clusterName)
+		assert.NoError(tt, err)
+		assert.Equal(tt, "sandbox-111111", clusterName)
 	})
 
 	t.Run("errors when switching to a cluster that does not exist", func(tt *testing.T) {
 		err := runSwitch(emptyConfig, "egg")
-		require.Error(tt, err)
+		assert.Error(tt, err)
 		assert.Contains(tt, err.Error(), "cluster switch unsuccessful")
 	})
 }

--- a/pkg/pharos/config/config.go
+++ b/pkg/pharos/config/config.go
@@ -20,6 +20,7 @@ type Config struct {
 
 const (
 	directoryPermissions = 0700
+	filePermissions      = 0644
 )
 
 // New creates a new Config reference at the given file path.
@@ -50,4 +51,24 @@ func (c *Config) Load() error {
 	}
 
 	return json.Unmarshal(raw, c)
+}
+
+// Save saves data from the Config struct into the config file.
+func (c *Config) Save() error {
+	path := filepath.Dir(c.filePath)
+	err := os.MkdirAll(path, directoryPermissions)
+	if err != nil {
+		return err
+	}
+
+	raw, err := json.MarshalIndent(c, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	err = ioutil.WriteFile(c.filePath, raw, filePermissions)
+	if err != nil {
+		return err
+	}
+	return nil
 }

--- a/pkg/pharos/config/config_test.go
+++ b/pkg/pharos/config/config_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/lob/pharos/internal/test"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -58,5 +59,30 @@ func TestLoad(t *testing.T) {
 		err = c.Load()
 		assert.Error(tt, err)
 		assert.Contains(tt, err.Error(), "pharos hasn't been configured yet")
+	})
+}
+
+func TestSave(t *testing.T) {
+	t.Run("successfully saves to empty config", func(tt *testing.T) {
+		// Create temporary empty test config file and defer cleanup.
+		emptyConfigFile := test.CopyTestFile(tt, "../testdata", "config", empty)
+		defer os.Remove(emptyConfigFile)
+
+		// Create config reference to empty file.
+		c, err := New(emptyConfigFile)
+		assert.NoError(tt, err)
+		assert.Equal(tt, emptyConfigFile, c.filePath)
+
+		// Edit config and save it to file.
+		c.AWSProfile = "egg"
+		err = c.Save()
+		assert.NoError(tt, err)
+
+		// Check to see if file was saved successfully.
+		c1, err := New(emptyConfigFile)
+		assert.NoError(tt, err)
+		err = c1.Load()
+		assert.NoError(tt, err)
+		assert.Equal(tt, "egg", c1.AWSProfile)
 	})
 }


### PR DESCRIPTION
### what & why
- setup command to help people setup the pharos cli config via the cli
- also some small edits/nits that hadn't been brought up yet in very early commits (changing requires to asserts, etc.)
- add description to clusters command

### testing the CLI locally
![image](https://user-images.githubusercontent.com/10638317/60550391-ab2b7180-9cdc-11e9-98a5-188ec2e5a249.png)
