### PR TITLE
chore(release): add release functionality

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,13 +51,26 @@ jobs:
           path: coverage.out
   release:
     docker:
-      - image: circleci/golang:1.10
+      - image: circleci/golang:1.12.5
+    working_directory: /go/src/github.com/lob/pharos
     steps:
       - checkout
       - run:
+          name: Install dependencies
+          command: make install
+      - run:
           name: Run goreleaser
           command: curl -sL https://git.io/goreleaser | bash
-    filters:
+
+workflows:
+  version: 2
+  build:
+    jobs:
+    - build
+  release:
+    jobs:
+    - release:
+        filters:
           branches:
             ignore: /.*/
           tags:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,6 +49,23 @@ jobs:
           command: make enforce
       - store_artifacts:
           path: coverage.out
+  release:
+    docker:
+      - image: circleci/golang:1.10
+    steps:
+      - checkout
+      - run: curl -sL https://git.io/goreleaser | bash
+
+workflows:
+  version: 2
+  release:
+    jobs:
+      - release:
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*(-.*)*/
 
 experimental:
   notify:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,18 +54,14 @@ jobs:
       - image: circleci/golang:1.10
     steps:
       - checkout
-      - run: curl -sL https://git.io/goreleaser | bash
-
-workflows:
-  version: 2
-  release:
-    jobs:
-      - release:
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*(-.*)*/
+      - run:
+          name: Run goreleaser
+          command: curl -sL https://git.io/goreleaser | bash
+    filters:
+          branches:
+            ignore: /.*/
+          tags:
+            only: /v[0-9]+(\.[0-9]+)*(-.*)*/
 
 experimental:
   notify:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
           POSTGRES_USER: pharos_admin
           POSTGRES_DB: pharos_test
     environment:
-      - ENVIRONMENT: "test"
+      ENVIRONMENT: "test"
     working_directory: /go/src/github.com/lob/pharos
     steps:
       - restore_cache:
@@ -53,8 +53,14 @@ jobs:
     docker:
       - image: circleci/golang:1.12.5
     working_directory: /go/src/github.com/lob/pharos
+    environment:
+      ENVIRONMENT: "production"
     steps:
       - checkout
+      - setup_remote_docker
+      - run:
+          name: Docker login
+          command: docker login -u="$DOCKER_USER" -p="$DOCKER_PASSWORD"
       - run:
           name: Install dependencies
           command: make install

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,14 +53,12 @@ jobs:
     docker:
       - image: circleci/golang:1.12.5
     working_directory: /go/src/github.com/lob/pharos
-    environment:
-      ENVIRONMENT: "production"
     steps:
       - checkout
       - setup_remote_docker
       - run:
           name: Docker login
-          command: docker login -u="$DOCKER_USER" -p="$DOCKER_PASSWORD"
+          command: echo $DOCKER_PASSWORD | docker login -u="$DOCKER_USER" --password-stdin
       - run:
           name: Install dependencies
           command: make install
@@ -70,17 +68,17 @@ jobs:
 
 workflows:
   version: 2
-  build:
+  build_and_release:
     jobs:
-    - build
-  release:
-    jobs:
-    - release:
-        filters:
-          branches:
-            ignore: /.*/
-          tags:
-            only: /v[0-9]+(\.[0-9]+)*(-.*)*/
+      - build
+      - release:
+          requires:
+            - build
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*(-.*)*/
 
 experimental:
   notify:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -2,14 +2,14 @@ project_name: pharos
 builds:
 - id: "pharos"
   main: ./cmd/pharos
-  binary: bin/pharos
+  binary: pharos
   goarch:
     - amd64
   goos:
     - linux
     - darwin
   ldflags:
-    -X github.com/emilyzhang/pharos/pkg/pharos/cmd.pharosVersion={{.Version}}
+    -X github.com/lob/pharos/pkg/pharos/cmd.pharosVersion={{.Version}}
 archives:
 - id: "pharos"
   builds:
@@ -33,12 +33,25 @@ brews:
     system "#{bin}/pharos --version"
   install: |
     bin.install "pharos"
+dockers:
+- goos: linux
+  goarch: amd64
+  image_templates:
+  - "lobcom/pharos:latest"
+  - "lobcom/pharos:{{ .Tag }}"
+  dockerfile: Dockerfile
+  extra_files:
+  - Gopkg.lock
+  - Gopkg.toml
+  - .dockerignore
+  - cmd
+  - internal
+  - pkg
 checksum:
   name_template: 'checksums.txt'
 snapshot:
   name_template: "{{ .Tag }}-snapshot"
 changelog:
-  sort: asc
   filters:
     exclude:
     - '^docs:'

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,20 +1,22 @@
+project_name: pharos
 builds:
 - id: "pharos"
-  main: cmd/pharos/main.go
+  main: ./cmd/pharos
   binary: bin/pharos
-- id: "pharos-api-server"
-  main: cmd/pharos-api-server/main.go
-  binary: bin/pharos-api-server
+  goarch:
+    - amd64
+  goos:
+    - linux
+    - darwin
+  ldflags:
+    -X github.com/emilyzhang/pharos/pkg/pharos/cmd.pharosVersion={{.Version}}
 archives:
 - id: "pharos"
   builds:
     - "pharos"
-    - "pharos-api-server"
   replacements:
     amd64: 64-bit
-    386: 32-bit
     darwin: macOS
-  format: zip
   files:
     - LICENSE
 checksum:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -19,6 +19,20 @@ archives:
     darwin: macOS
   files:
     - LICENSE
+brews:
+- name: "pharos"
+  ids:
+  - "pharos"
+  github:
+    owner: lob
+    name: homebrew-internal
+  folder: Formula
+  homepage: "https://github.com/lob/pharos"
+  description: "CLI for discovery and distribution of kubeconfig files."
+  test: |
+    system "#{bin}/pharos --version"
+  install: |
+    bin.install "pharos"
 checksum:
   name_template: 'checksums.txt'
 snapshot:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,29 @@
+builds:
+- id: "pharos"
+  main: cmd/pharos/main.go
+  binary: bin/pharos
+- id: "pharos-api-server"
+  main: cmd/pharos-api-server/main.go
+  binary: bin/pharos-api-server
+archives:
+- id: "pharos"
+  builds:
+    - "pharos"
+    - "pharos-api-server"
+  replacements:
+    amd64: 64-bit
+    386: 32-bit
+    darwin: macOS
+  format: zip
+  files:
+    - LICENSE
+checksum:
+  name_template: 'checksums.txt'
+snapshot:
+  name_template: "{{ .Tag }}-snapshot"
+changelog:
+  sort: asc
+  filters:
+    exclude:
+    - '^docs:'
+    - '^test:'

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2019 Lob.com
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,8 @@
 BIN_DIR         ?= ./bin
 PKG_SERVER_NAME ?= pharos-api-server
 PKG_CLI_NAME    ?= pharos
-VERSION         ?= v1.0.0
+LDFLAGS         ?= "-X github.com/lob/pharos/pkg/pharos/cmd.pharosVersion=$(VERSION)"
+VERSION         ?=
 
 COVERAGE_PROFILE ?= coverage.out
 
@@ -22,7 +23,7 @@ default: build
 build:
 	@echo "---> Building"
 	go build -o $(BIN_DIR)/$(PKG_SERVER_NAME) ./cmd/pharos-api-server
-	go build -o $(BIN_DIR)/$(PKG_CLI_NAME) ./cmd/pharos
+	go build -o $(BIN_DIR)/$(PKG_CLI_NAME) -ldflags $(LDFLAGS) ./cmd/pharos
 
 .PHONY: clean
 clean:

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 BIN_DIR         ?= ./bin
 PKG_SERVER_NAME ?= pharos-api-server
 PKG_CLI_NAME    ?= pharos
+VERSION         ?= v1.0.0
 
 COVERAGE_PROFILE ?= coverage.out
 
@@ -88,3 +89,10 @@ start:
 test:
 	@echo "---> Testing"
 	ENVIRONMENT=test go test ./pkg/... -race -coverprofile $(COVERAGE_PROFILE)
+
+.PHONY: release
+release:
+	@echo "---> Creating tagged release"
+	git tag $(VERSION)
+	git push origin
+	git push origin --tags

--- a/Makefile
+++ b/Makefile
@@ -94,6 +94,9 @@ test:
 .PHONY: release
 release:
 	@echo "---> Creating tagged release"
+ifndef VERSION
+	$(error VERSION must be specified)
+endif
 	git tag $(VERSION)
 	# Check that the commit is tagged and starts with "v".
 	[[ $$(git tag -l --points-at HEAD) == v* ]]

--- a/Makefile
+++ b/Makefile
@@ -95,5 +95,7 @@ test:
 release:
 	@echo "---> Creating tagged release"
 	git tag $(VERSION)
+	# Check that the commit is tagged and starts with "v".
+	[[ $$(git tag -l --points-at HEAD) == v* ]]
 	git push origin
 	git push origin --tags

--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@ functional. 🚨
 Pharos is an open-source Kubernetes cluster discovery and configuration distribution tool designed
 to work nicely with [aws-iam-authenticator](https://github.com/kubernetes-sigs/aws-iam-authenticator).
 
-## Testing Locally
+## Development
+### Testing Locally
 Build the Pharos API server and Pharos CLI:
 ```
 make install
@@ -55,3 +56,12 @@ Example: `bin/pharos clusters get sandbox -c pkg/pharos/testdata/pharosConfig -f
 command will create a new kubeconfig file at `./test/test1` if it succeeds.
 
 Happy testing!
+
+### Making New Releases
+Navigate to `$GOPATH/src/github.com/lob/pharos`, make sure that you're on the master branch and
+up to date with the remote repository, and run
+```
+make release VERSION=<VERSION-TAG>
+```
+where VERSION-TAG is a string that begins with `v` followed by a version number following the
+[semantic versioning spec](https://semver.org/). An example would be `make release VERSION=v1.1.0`.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@ functional. 🚨
 Pharos is an open-source Kubernetes cluster discovery and configuration distribution tool designed
 to work nicely with [aws-iam-authenticator](https://github.com/kubernetes-sigs/aws-iam-authenticator).
 
-
 ## Testing Locally
 Build the Pharos API server and Pharos CLI:
 ```

--- a/pkg/pharos/cmd/root.go
+++ b/pkg/pharos/cmd/root.go
@@ -15,7 +15,7 @@ var (
 	file          string
 	inactive      bool
 	pharosConfig  string
-	pharosVersion string // pharosVersion is set by ldflags in the Makefile.
+	pharosVersion = "0.0.0" // pharosVersion can be overwritten by ldflags in the Makefile.
 )
 
 // rootCmd represents the base command when called without any subcommands.

--- a/pkg/pharos/cmd/root.go
+++ b/pkg/pharos/cmd/root.go
@@ -10,11 +10,12 @@ import (
 
 // Declare some variables to be used as flags in various commands.
 var (
-	dryRun       bool
-	environment  string
-	file         string
-	inactive     bool
-	pharosConfig string
+	dryRun        bool
+	environment   string
+	file          string
+	inactive      bool
+	pharosConfig  string
+	pharosVersion string // pharosVersion is set by ldflags in the Makefile.
 )
 
 // rootCmd represents the base command when called without any subcommands.
@@ -22,7 +23,7 @@ var rootCmd = &cobra.Command{
 	Use:     "pharos",
 	Short:   "A tool for managing kubeconfig files.",
 	Long:    "Pharos is a tool for cluster discovery and distribution of kubeconfig files.",
-	Version: "1.0.0",
+	Version: pharosVersion,
 }
 
 // clustersCmd is the pharos clusters command.

--- a/pkg/pharos/cmd/root.go
+++ b/pkg/pharos/cmd/root.go
@@ -22,7 +22,7 @@ var rootCmd = &cobra.Command{
 	Use:     "pharos",
 	Short:   "A tool for managing kubeconfig files.",
 	Long:    "Pharos is a tool for cluster discovery and distribution of kubeconfig files.",
-	Version: "1.0",
+	Version: "1.0.0",
 }
 
 // clustersCmd is the pharos clusters command.
@@ -39,8 +39,8 @@ func Execute() error {
 }
 
 func init() {
-	rootCmd.Flags().BoolP("version", "v", false, "print pharos version number")
-	rootCmd.PersistentFlags().StringVarP(&pharosConfig, "config", "c", fmt.Sprintf("%s/.kube/pharos/config", os.Getenv("HOME")), "pharos config file")
+	rootCmd.Flags().BoolP("version", "v", false, "print Pharos version number")
+	rootCmd.PersistentFlags().StringVarP(&pharosConfig, "config", "c", fmt.Sprintf("%s/.kube/pharos/config", os.Getenv("HOME")), "Pharos config file")
 
 	// Prevent usage message from being printed out upon command error.
 	rootCmd.SilenceUsage = true


### PR DESCRIPTION
### what & why
- sets up the github release process for pharos
- adds Apache 2 license

### notes
- goreleaser publishes to our internal homebrew tap and docker repo at lobcom/pharos
