### PR TITLE
fix(kubeconfig): decode cluster-authority-data returned by server

### DIFF
--- a/pkg/pharos/cli/kubeconfig.go
+++ b/pkg/pharos/cli/kubeconfig.go
@@ -1,6 +1,8 @@
 package cli
 
 import (
+	"encoding/base64"
+
 	"github.com/lob/pharos/pkg/util/model"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
@@ -51,8 +53,10 @@ func newUser(id string, environment string) *clientcmdapi.AuthInfo {
 // newCluster returns a pointer to a new clientcmdapi.Cluster containing
 // information from a cluster.
 func newCluster(c model.Cluster) *clientcmdapi.Cluster {
+	clusterAuthorityData, _ := base64.StdEncoding.DecodeString(c.ClusterAuthorityData)
+
 	cluster := clientcmdapi.NewCluster()
 	cluster.Server = c.ServerURL
-	cluster.CertificateAuthorityData = []byte(c.ClusterAuthorityData)
+	cluster.CertificateAuthorityData = clusterAuthorityData
 	return cluster
 }


### PR DESCRIPTION
## What
- [x] base64 decode the `ClusterAuthorityData` returned by the API Server to the CLI.

## Why
For simplicity and convenience sake we are using the [k8s clientcmd library](https://github.com/lob/pharos/blob/798ce9932e1ff842a03291709d86d142949eacc6/pkg/pharos/cli/cli.go#L112-L126) to write the Kubeconfig file. It turns out that when it's encoding the `[]byte` data it already base64 encodes it. We already have the base64 encoded data from the API server so we need to decode it before setting it in the model to avoid doubly-encoding the data.