### PR TITLE
feat(Dockerfile): add migration binary to docker image to allow for easy migrations

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ RUN dep ensure -vendor-only
 COPY . .
 
 RUN CGO_ENABLED=0 GOOS=linux go build -ldflags "-w -s" -o ./bin/pharos-api-server ./cmd/pharos-api-server
+RUN CGO_ENABLED=0 GOOS=linux go build -ldflags "-w -s" -o ./bin/migrations ./cmd/migrations/*.go
 
 FROM alpine:3.8
 
@@ -28,6 +29,6 @@ RUN cd /tmp/rds-ca && awk '/-BEGIN CERTIFICATE-/{close(x); x=++i;}{print > "cert
     && rm -rf /tmp/rds-ca \
     && update-ca-certificates
 
-COPY --from=build /go/src/github.com/lob/pharos/bin/pharos-api-server .
+COPY --from=build /go/src/github.com/lob/pharos/bin .
 
 CMD ["./pharos-api-server"]


### PR DESCRIPTION
## What
- [x] Compile and add the migration binary alongside the Docker image

## Why
Allow pharos users to easily run migrations on the underlying database to be able to use pharos.

## Usage
The migrations can be run by overwriting the default `CMD` and running `./migrations migrate` instead (with the appropriate ENV variables set).

```bash
docker run --rm --name pharos pharos:latest ./migrations migrate
```
