### PR TITLE
fix(circleci): fix workflow tag trigger issue

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,7 +70,10 @@ workflows:
   version: 2
   build_and_release:
     jobs:
-      - build
+      - build:
+          filters:
+            tags:
+              only: /.*/
       - release:
           requires:
             - build


### PR DESCRIPTION
### what & why
- circleci wasn't triggering properly on tags, so i added a filter to not ignore tags on the build job

### notes
- this is a previously reported bug: https://discuss.circleci.com/t/build-workflow-not-triggered-when-tag-is-pushed/19577