### PR TITLE
chore(clusters): add ability to export clusters cmd

### DIFF
--- a/pkg/pharos/cmd/clusters.go
+++ b/pkg/pharos/cmd/clusters.go
@@ -1,0 +1,26 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// NewClustersCmd returns a new cobra.Command with all the necessary clusters
+// sub-commands attached to it.
+func NewClustersCmd() *cobra.Command {
+	var cmd = &cobra.Command{
+		Use:   "clusters",
+		Short: `Commands for cluster management (run "pharos clusters -h" for a full list of cluster commands)`,
+		Long:  "Commands for managing cluster kubeconfig files.",
+	}
+
+	cmd.AddCommand(CreateCmd)
+	cmd.AddCommand(CurrentCmd)
+	cmd.AddCommand(DeleteCmd)
+	cmd.AddCommand(GetCmd)
+	cmd.AddCommand(ListCmd)
+	cmd.AddCommand(SwitchCmd)
+	cmd.AddCommand(SyncCmd)
+	cmd.AddCommand(UpdateCmd)
+
+	return cmd
+}

--- a/pkg/pharos/cmd/root.go
+++ b/pkg/pharos/cmd/root.go
@@ -26,13 +26,6 @@ var rootCmd = &cobra.Command{
 	Version: pharosVersion,
 }
 
-// clustersCmd is the pharos clusters command.
-var clustersCmd = &cobra.Command{
-	Use:   "clusters",
-	Short: `Commands for cluster management (run "pharos clusters -h" for a full list of cluster commands)`,
-	Long:  "Commands for managing cluster kubeconfig files.",
-}
-
 // Execute adds all child commands to the root command and sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() error {
@@ -53,16 +46,8 @@ func init() {
 
 	// Add child commands.
 	rootCmd.AddCommand(completionCmd)
-	rootCmd.AddCommand(clustersCmd)
+	rootCmd.AddCommand(NewClustersCmd())
 	rootCmd.AddCommand(setupCmd)
-	clustersCmd.AddCommand(CreateCmd)
-	clustersCmd.AddCommand(CurrentCmd)
-	clustersCmd.AddCommand(DeleteCmd)
-	clustersCmd.AddCommand(GetCmd)
-	clustersCmd.AddCommand(ListCmd)
-	clustersCmd.AddCommand(SwitchCmd)
-	clustersCmd.AddCommand(SyncCmd)
-	clustersCmd.AddCommand(UpdateCmd)
 }
 
 // argID prevents commands from being run unless exactly one argument (a cluster name or id)


### PR DESCRIPTION
## What
- [x] Refactor `clustersCmd` to allow for it to be exported out of pharos and imported by third-party application.

## Why
We'd like to import the `clusters` Pharos sub-command into an internal application.