### PR TITLE
fix(aws): use defaults if no profile provided

### DIFF
--- a/pkg/pharos/api/client.go
+++ b/pkg/pharos/api/client.go
@@ -50,7 +50,7 @@ func ClientFromConfig(configFile string) (*Client, error) {
 	}
 
 	// Create token generator.
-	var s *aws.Session
+	var s *session.Session
 	if c.AWSProfile == "" {
 		s, err = session.NewSession()
 	} else {

--- a/pkg/pharos/api/client.go
+++ b/pkg/pharos/api/client.go
@@ -50,7 +50,12 @@ func ClientFromConfig(configFile string) (*Client, error) {
 	}
 
 	// Create token generator.
-	s, err := session.NewSessionWithOptions(session.Options{Profile: c.AWSProfile})
+	var s *aws.Session
+	if c.AWSProfile == "" {
+		s, err = session.NewSession()
+	} else {
+		s, err = session.NewSessionWithOptions(session.Options{Profile: c.AWSProfile})
+	}
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to create session for authorization token")
 	}


### PR DESCRIPTION
This will be helpful in CI, where there is no profile but there are access keys.