### PR TITLE
fix(circle): make circle cache properly on tag builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,16 +11,7 @@ jobs:
       ENVIRONMENT: "test"
     working_directory: /go/src/github.com/lob/pharos
     steps:
-      - restore_cache:
-          keys:
-            - source-v1-{{ .Branch }}-{{ .Revision }}
-            - source-v1-{{ .Branch }}-
-            - source-v1-
       - checkout
-      - save_cache:
-          key: source-v1-{{ .Branch }}-{{ .Revision }}
-          paths:
-            - /go/src/github.com/lob/pharos/.git
       - restore_cache:
           keys:
             - vendor-{{ checksum "Gopkg.lock" }}


### PR DESCRIPTION
[with the branch/revision cache](https://circleci.com/workflow-run/a72868cd-852e-4d93-84ac-c3ec8cf62ea2) versus [without the branch/revision cache](https://circleci.com/workflow-run/5d22ad5a-cf88-4fd8-afde-94dba12716ab)

On builds off Git tags, it fails the old way. This also more closely resembles captain's circle config, [see](https://github.com/lob/captain/blob/master/.circleci/config.yml#L8-L23)?